### PR TITLE
Matrix Synapse Dependency Update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,4 +30,4 @@ coverage==4.5.1
 bump2version==0.5.8
 
 # Test support
-matrix-synapse==0.33.9
+matrix-synapse==1.3.1


### PR DESCRIPTION
The matrix dependency update is requested because, now the tests fail to run