### PR TITLE
Checksummed addresses when creating light payment

### DIFF
--- a/raiden/lightclient/lightclientmessages/light_client_payment.py
+++ b/raiden/lightclient/lightclientmessages/light_client_payment.py
@@ -1,5 +1,6 @@
 import string
 from enum import Enum
+from eth_utils import to_checksum_address
 
 from raiden.utils.typing import AddressHex, TokenNetworkID, Secret
 
@@ -29,8 +30,8 @@ class LightClientPayment:
 
     ):
         self.payment_id = identifier
-        self.light_client_address = light_client_address
-        self.partner_address = partner_address
+        self.light_client_address = to_checksum_address(light_client_address)
+        self.partner_address = to_checksum_address(partner_address)
         self.is_lc_initiator = is_lc_initiator
         self.token_network_id = token_network_id
         self.amount = amount

--- a/raiden/lightclient/lightclientmessages/light_client_payment.py
+++ b/raiden/lightclient/lightclientmessages/light_client_payment.py
@@ -33,7 +33,7 @@ class LightClientPayment:
         self.light_client_address = to_checksum_address(light_client_address)
         self.partner_address = to_checksum_address(partner_address)
         self.is_lc_initiator = is_lc_initiator
-        self.token_network_id = token_network_id
+        self.token_network_id = to_checksum_address(token_network_id)
         self.amount = amount
         self.created_on = created_on
         self.payment_status = payment_status

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -167,10 +167,10 @@ class SQLiteStorage:
                 "payment_status "
                 ") VALUES(?, ?, ?, ?, ?,  ?, ?, ?)",
                 (light_client_payment.payment_id,
-                 to_checksum_address(light_client_payment.light_client_address),
+                 light_client_payment.light_client_address,
                  light_client_payment.partner_address,
                  light_client_payment.is_lc_initiator,
-                 to_checksum_address(light_client_payment.token_network_id),
+                 light_client_payment.token_network_id,
                  light_client_payment.amount,
                  light_client_payment.created_on,
                  str(light_client_payment.payment_status.value))


### PR DESCRIPTION
Partner Address was getting stored as bytes sometimes.
Now Partner and light client addresses are getting stored as checksummed addresses.