### PR TITLE
Parse identifiers and amounts in incoming Message

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -585,6 +585,26 @@ class APIServer(Runnable):
         return api_error([str(exception)], HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
+def parse_message_number(message):
+    if message["type"] == "LockedTransfer":
+        message["payment_identifier"] = int(message["payment_identifier"])
+        message["message_identifier"] = int(message["message_identifier"])
+        message["transferred_amount"] = int(message["transferred_amount"])
+    elif message["type"] == "Delivered":
+        message["delivered_message_identifier"] = int(message["delivered_message_identifier"])
+    elif message["type"] == "RevealSecret":
+        message["message_identifier"] = int(message["message_identifier"])
+    elif message["type"] == "Secret":
+        message["payment_identifier"] = int(message["payment_identifier"])
+        message["message_identifier"] = int(message["message_identifier"])
+        message["transferred_amount"] = int(message["transferred_amount"])
+    elif message["type"] == "Processed":
+        message["message_identifier"] = int(message["message_identifier"])
+    elif message["type"] == "SecretRequest":
+        message["payment_identifier"] = int(message["payment_identifier"])
+        message["message_identifier"] = int(message["message_identifier"])
+    return message
+
 class RestAPI:
     """
     This wraps around the actual RaidenAPI in api/python.
@@ -2033,7 +2053,7 @@ class RestAPI:
         if not api_key:
             return ApiErrorBuilder.build_and_log_error(errors="Missing api_key auth header",
                                                        status_code=HTTPStatus.BAD_REQUEST, log=log)
-
+        message = parse_message_number(message)
         payment_request = LightClientService.get_light_client_payment(message_id, self.raiden_api.raiden.wal)
         if not payment_request:
             return ApiErrorBuilder.build_and_log_error(errors="No payment associated",


### PR DESCRIPTION
The LC SDK has a limitiation due to JS integer handling big values can lead to truncation, and therefore problems in the protocol.

This method parses according to the message the identifiers or amounts to int, because the LC SDK has to handle them as strings in order not to lose precision.