### PR TITLE
Fix for handle_batch_unlock in token_network

### DIFF
--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -210,6 +210,8 @@ def test_channel_data_removed_after_unlock(
         block_hash=closed_block_hash,
     )
     channel_state_after_closed = channel_closed_iteration.new_state.channelidentifiers_to_channels[
+        channel_state.our_state.address
+    ][
         channel_state.identifier
     ]
 
@@ -221,6 +223,7 @@ def test_channel_data_removed_after_unlock(
         block_hash=factories.make_block_hash(),
         our_onchain_locksroot=merkleroot(channel_state_after_closed.our_state.merkletree),
         partner_onchain_locksroot=merkleroot(channel_state_after_closed.partner_state.merkletree),
+        participant1=our_address,
     )
 
     channel_settled_iteration = token_network.state_transition(
@@ -233,7 +236,7 @@ def test_channel_data_removed_after_unlock(
     token_network_state_after_settle = channel_settled_iteration.new_state
     ids_to_channels = token_network_state_after_settle.channelidentifiers_to_channels
     assert len(ids_to_channels) == 1
-    assert channel_state.identifier in ids_to_channels
+    assert channel_state.identifier in ids_to_channels[channel_state.our_state.address]
 
     unlock_blocknumber = settle_block_number + 5
     channel_batch_unlock_state_change = ContractReceiveChannelBatchUnlock(
@@ -255,7 +258,7 @@ def test_channel_data_removed_after_unlock(
     )
 
     token_network_state_after_unlock = channel_unlock_iteration.new_state
-    ids_to_channels = token_network_state_after_unlock.channelidentifiers_to_channels
+    ids_to_channels = token_network_state_after_unlock.channelidentifiers_to_channels[chain_state.our_address]
     assert len(ids_to_channels) == 0
 
 

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -207,7 +207,7 @@ def handle_batch_unlock(
     block_hash: BlockHash,
 ) -> TransitionResult:
     events = list()
-    channel_state = token_network_state.channelidentifiers_to_channels.get(
+    channel_state = token_network_state.channelidentifiers_to_channels[state_change.participant].get(
         state_change.canonical_identifier.channel_identifier
     )
     if channel_state is not None:
@@ -224,7 +224,7 @@ def handle_batch_unlock(
                 channel_state.partner_state.address
             ].remove(channel_state.identifier)
 
-            del token_network_state.channelidentifiers_to_channels[channel_state.identifier]
+            del token_network_state.channelidentifiers_to_channels[state_change.participant][channel_state.identifier]
 
     return TransitionResult(token_network_state, events)
 


### PR DESCRIPTION
It was looking into channelidentifiers_to_channels only by channel_identifier, new structure needs node_address to get later the channel_identifier.