### PR TITLE
Perform check when trying to get channel from channelidentifiers_to_channels

### DIFF
--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -296,7 +296,9 @@ def handle_transferrefundcancelroute(
         return TransitionResult(payment_state, list())
 
     channel_identifier = initiator_state.channel_identifier
-    channel_state = channelidentifiers_to_channels.get(channel_identifier)
+    channel_state = channelidentifiers_to_channels.get(initiator_state.transfer.initiator)
+    if channel_state:
+        channel_state = channel_state.get(channel_identifier)
 
     if not channel_state:
         return TransitionResult(payment_state, list())


### PR DESCRIPTION
A test was failing cause it was trying to get over a None return, "None.get(channel_identifier)"

