### PR TITLE
Expired locked transfers are now stored in order that the LC can retr…

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -183,6 +183,7 @@ class RaidenEventHandler(EventHandler):
             store_message_event.payment_id,
             store_message_event.message_order,
             store_message_event.message_type,
+            store_message_event.message.to_dict()["type"],
             raiden.wal)
         if not existing_message:
             LightClientMessageHandler.store_light_client_protocol_message(store_message_event.message_id,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -181,7 +181,7 @@ class SQLiteStorage:
     def update_light_client_payment_status(self, light_client_payment_id, status):
         with self.write_lock, self.conn:
             cursor = self.conn.execute(
-                "UPDATE light_client_payment SET payment_status =? WHERE payment_hash=?", (str(status.value), light_client_payment_id)
+                "UPDATE light_client_payment SET payment_status =? WHERE payment_id=?", (str(status.value), light_client_payment_id)
             )
             last_id = cursor.lastrowid
 


### PR DESCRIPTION
This PR includes: 

- Persistence of already expired `LockedTransfers `in order that the `light client` can retrieve them and send `Delivered `messages
- Modifications on  `is_light_client_protocol_message_already_stored`, to take into account the message type