### PR TITLE
Missing parameter in wait_for_settle

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -180,6 +180,7 @@ class ConnectionManager:
                 self.token_address,
                 channel_ids,
                 self.raiden.alarm.sleep_time,
+                partner_addresses,
             )
 
         return channels_to_close

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -277,6 +277,8 @@ def wait_for_settle(
     token_address: TokenAddress,
     channel_ids: List[ChannelID],
     retry_timeout: float,
+    partner_addresses: List[Address],
+
 ) -> None:
     """Wait until all channels are settled.
 
@@ -290,6 +292,7 @@ def wait_for_settle(
         channel_ids=channel_ids,
         retry_timeout=retry_timeout,
         target_states=(CHANNEL_STATE_SETTLED,),
+        partner_addresses=partner_addresses,
     )
 
 


### PR DESCRIPTION
This PR fixes a missed parameter (Partner_addresses) in wait_for_settle function. 
-This function is used in token tab when trying to "leave network" of a token.
Now it closes the channels as expected
