### PR TITLE
RLP-639/Contract without code

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -53,8 +53,6 @@ def handle_tokennetwork_new(raiden: "RaidenService", event: Event):
     token_network_address = args["token_network_address"]
     token_address = typing.TokenAddress(args["token_address"])
     block_hash = data["block_hash"]
-    # from raiden.network.rpc.client import check_address_has_code
-    # check_address_has_code(raiden.chain.client, token_network_address, 'TokenNetwork')
     try:
         token_network_proxy = raiden.chain.token_network(token_network_address)
         raiden.blockchain_events.add_token_network_listener(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -182,7 +182,7 @@ def check_address_has_code(client: "JSONRPCClient", address: Address, contract_n
     """ Checks that the given address contains code. """
     result = client.web3.eth.getCode(to_checksum_address(address), "latest")
 
-    if not result:
+    if not result or result == b'\x00':
         if contract_name:
             formated_contract_name = "[{}]: ".format(contract_name)
         else:


### PR DESCRIPTION
This fixes when a Token has no code, maybe because the address runs out of gas, or similar problems that makes the token get deployed without any code.
-When trying to get the code of the token, it was returning 0x00. Added a condition for that returning code.
-Now handling exception AddressWithoutCode and gets logged into console.