### PR TITLE
RLP-406 Each client has a different password for each homeserver

### DIFF
--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS light_client_payment(
     amount TEXT NOT NULL,
     created_on TEXT NOT NULL,
     payment_status  TEXT CHECK  (payment_status in ('InProgress', 'Expired', 'Failed', 'Done', 'Pending', 'Deleted' ) ) NOT NULL DEFAULT 'Pending',
-    FOREIGN KEY(light_client_address) REFERENCES client(address)
+    FOREIGN KEY(light_client_address) REFERENCES client(address) ON DELETE CASCADE ON UPDATE CASCADE
 );
 """
 
@@ -116,13 +116,12 @@ DB_CREATE_LIGHT_CLIENT_PROTOCOL_MESSAGE = """
 CREATE TABLE IF NOT EXISTS light_client_protocol_message (
     internal_msg_identifier INTEGER PRIMARY KEY AUTOINCREMENT,
     identifier TEXT,
-    light_client_payment_id TEXT NULLABLE REFERENCES light_client_payment(payment_id),
+    light_client_payment_id TEXT NULLABLE REFERENCES light_client_payment(payment_id) ON DELETE CASCADE ON UPDATE CASCADE,
     message_order INTEGER,
     unsigned_message JSON,
     signed_message JSON,
     message_type TEXT CHECK (message_type in ('PaymentSuccessful', 'PaymentFailure', 'PaymentExpired', 'SettlementRequired')) NOT NULL
-
-    );
+);
 """
 
 DB_CREATE_LIGHT_CLIENT_BALANCE_PROOF = """
@@ -136,8 +135,8 @@ CREATE TABLE IF NOT EXISTS light_client_balance_proof (
     token_network_address TEXT,
     balance_proof JSON,
     lc_balance_proof_signature TEXT,
-    FOREIGN KEY(light_client_payment_id)  REFERENCES light_client_payment(payment_id)
-    );
+    FOREIGN KEY(light_client_payment_id)  REFERENCES light_client_payment(payment_id) ON DELETE CASCADE ON UPDATE CASCADE
+);
 """
 
 DB_SCRIPT_CREATE_TABLES = """

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -107,7 +107,7 @@ def _setup_matrix(config):
                     # delete it and respond with an error to control the re-onboard
                     storage.flag_light_client_as_pending_for_deletion(light_client["address"])
                     log.info("No available server with name " + current_server_name +
-                             ", LC has been deleted from DB, on-boarding is needed for LC with address: " +
+                             ", LC has been flagged for deletion from DB, on-boarding is needed for LC with address: " +
                              light_client["address"])
                     continue
 


### PR DESCRIPTION
* This commit fixes the data integrity of the client table, now we can delete clients without having a foreign key error, this solves an error introduced by [this](https://github.com/rsksmart/lumino/pull/78) PR 

* Also fixes a log syntax problem