### PR TITLE
RLP-574 Delete/Update old non closing balance proof

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -231,6 +231,7 @@ class PaymentChannel:
         partner_signature: Signature,
         signature: Signature,
         block_identifier: BlockSpecification,
+        raiden: "RaidenService"
     ):
         """ Updates the channel using the provided balance proof. """
         self.token_network.update_transfer_light(
@@ -243,6 +244,7 @@ class PaymentChannel:
             closing_signature=partner_signature,
             non_closing_signature=signature,
             given_block_identifier=block_identifier,
+            raiden=raiden
         )
 
     def update_transfer(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1742,7 +1742,7 @@ class TokenNetwork:
         else:
             log.info("updateNonClosingBalanceProof successful", **log_details)
         finally:
-            # if an error occurred we need to delete the non closing balance proof from the database
+            # we need to delete the non closing balance proof from the database to avoid re-send it
             log.info("Deleting non closing balance proof for channel id " + str(channel_identifier), **log_details)
             raiden.wal.storage.delete_light_client_non_closing_balance_proof(channel_id=channel_identifier)
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1437,6 +1437,7 @@ class TokenNetwork:
         closing_signature: Signature,
         non_closing_signature: Signature,
         given_block_identifier: BlockSpecification,
+        raiden: "RaidenService"
     ):
         log_details = {
             "token_network": pex(self.address),
@@ -1566,175 +1567,184 @@ class TokenNetwork:
             non_closing_signature=non_closing_signature,
         )
 
-        if gas_limit:
-            transaction_hash = self.proxy.transact(
-                "updateNonClosingBalanceProof",
-                safe_gas_limit(gas_limit, GAS_REQUIRED_FOR_UPDATE_BALANCE_PROOF),
-                channel_identifier=channel_identifier,
-                closing_participant=partner,
-                non_closing_participant=lc_address,
-                balance_hash=balance_hash,
-                nonce=nonce,
-                additional_hash=additional_hash,
-                closing_signature=closing_signature,
-                non_closing_signature=non_closing_signature,
-            )
+        try:
 
-            self.client.poll(transaction_hash)
-            receipt_or_none = check_transaction_threw(self.client, transaction_hash)
+            if gas_limit:
+                transaction_hash = self.proxy.transact(
+                    "updateNonClosingBalanceProof",
+                    safe_gas_limit(gas_limit, GAS_REQUIRED_FOR_UPDATE_BALANCE_PROOF),
+                    channel_identifier=channel_identifier,
+                    closing_participant=partner,
+                    non_closing_participant=lc_address,
+                    balance_hash=balance_hash,
+                    nonce=nonce,
+                    additional_hash=additional_hash,
+                    closing_signature=closing_signature,
+                    non_closing_signature=non_closing_signature,
+                )
 
-            if receipt_or_none:
-                # Because the gas estimation succeeded it is known that:
-                # - The channel existed.
-                # - The channel was at the state closed.
-                # - The partner node was the closing address.
-                # - The account had enough balance to pay for the gas (however
-                #   there is a race condition for multiple transactions #3890)
+                self.client.poll(transaction_hash)
+                receipt_or_none = check_transaction_threw(self.client, transaction_hash)
 
-                # These checks do not have problems with race conditions because
-                # `poll`ing waits for the transaction to be confirmed.
-                mining_block = int(receipt_or_none["blockNumber"])
+                if receipt_or_none:
+                    # Because the gas estimation succeeded it is known that:
+                    # - The channel existed.
+                    # - The channel was at the state closed.
+                    # - The partner node was the closing address.
+                    # - The account had enough balance to pay for the gas (however
+                    #   there is a race condition for multiple transactions #3890)
 
-                if receipt_or_none["cumulativeGasUsed"] == gas_limit:
-                    msg = (
-                        "update transfer failed and all gas was used. Estimate gas "
-                        "may have underestimated update transfer, or succeeded even "
-                        "though an assert is triggered, or the smart contract code "
-                        "has an conditional assert."
+                    # These checks do not have problems with race conditions because
+                    # `poll`ing waits for the transaction to be confirmed.
+                    mining_block = int(receipt_or_none["blockNumber"])
+
+                    if receipt_or_none["cumulativeGasUsed"] == gas_limit:
+                        msg = (
+                            "update transfer failed and all gas was used. Estimate gas "
+                            "may have underestimated update transfer, or succeeded even "
+                            "though an assert is triggered, or the smart contract code "
+                            "has an conditional assert."
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    channel_data = self._detail_channel(
+                        participant1=lc_address,
+                        participant2=partner,
+                        block_identifier=mining_block,
+                        channel_identifier=channel_identifier,
                     )
-                    raise RaidenRecoverableError(msg)
 
-                channel_data = self._detail_channel(
-                    participant1=lc_address,
+                    # The channel identifier can be set to 0 if the channel is
+                    # settled, or it could have a higher value if a new channel was
+                    # opened. A lower value is an unrecoverable error.
+                    was_channel_gone = (
+                        channel_data.channel_identifier == 0
+                        or channel_data.channel_identifier > channel_identifier
+                    )
+
+                    if was_channel_gone:
+                        msg = (
+                            f"The provided channel identifier does not match the value "
+                            f"on-chain at the block the update transfer was mined ({mining_block}). "
+                            f"provided_channel_identifier={channel_identifier}, "
+                            f"onchain_channel_identifier={channel_data.channel_identifier}"
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    if channel_data.state >= ChannelState.SETTLED:
+                        # This should never happen if the settlement window and gas
+                        # price estimation is done properly.
+                        #
+                        # This is a race condition that cannot be prevented,
+                        # therefore it is a recoverable error.
+                        msg = "Channel was already settled when update transfer was mined."
+                        raise RaidenRecoverableError(msg)
+
+                    if channel_data.settle_block_number < mining_block:
+                        # The channel is cleared from the smart contract's storage
+                        # on call to settle, this means that settle_block_number
+                        # may be zero, therefore this check must be done after the
+                        # channel's state check.
+                        #
+                        # This is a race condition that cannot be prevented,
+                        # therefore it is a recoverable error.
+                        msg = "update transfer was mined after the settlement " "window."
+                        raise RaidenRecoverableError(msg)
+
+                    partner_details = self._detail_participant(
+                        channel_identifier=channel_identifier,
+                        participant=partner,
+                        partner=lc_address,
+                        block_identifier=mining_block,
+                    )
+                    if partner_details.nonce != nonce:
+                        # A higher value should be impossible because a signature
+                        # from this node is necessary and this node should send the
+                        # partner's balance proof with the highest nonce
+                        #
+                        # A lower value means some unexpected failure.
+                        msg = (
+                            f"update transfer failed, the on-chain nonce is higher then our expected "
+                            f"value expected={nonce} actual={partner_details.nonce}"
+                        )
+                        raise RaidenUnrecoverableError(msg)
+
+                    if channel_data.state < ChannelState.CLOSED:
+                        msg = (
+                            f"The channel state changed unexpectedly. "
+                            f"block=({mining_block}) onchain_state={channel_data.state}"
+                        )
+                        raise RaidenUnrecoverableError(msg)
+
+                    raise RaidenUnrecoverableError("update transfer failed for an unknown reason")
+
+            else:
+                # The transaction would have failed if sent, figure out why.
+                # The latest block can not be used reliably because of reorgs,
+                # therefore every call using this block has to handle pruned data.
+                failed_at = self.proxy.jsonrpc_client.get_block("latest")
+                failed_at_blockhash = encode_hex(failed_at["hash"])
+                failed_at_blocknumber = failed_at["number"]
+
+                self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                    transaction_name="updateNonClosingBalanceProof",
+                    address=self.node_address,
+                    transaction_executed=False,
+                    required_gas=GAS_REQUIRED_FOR_UPDATE_BALANCE_PROOF,
+                    block_identifier=failed_at_blocknumber,
+                )
+
+                detail = self._detail_channel(
+                    participant1=self.node_address,
                     participant2=partner,
-                    block_identifier=mining_block,
+                    block_identifier=failed_at_blockhash,
                     channel_identifier=channel_identifier,
                 )
 
-                # The channel identifier can be set to 0 if the channel is
-                # settled, or it could have a higher value if a new channel was
-                # opened. A lower value is an unrecoverable error.
-                was_channel_gone = (
-                    channel_data.channel_identifier == 0
-                    or channel_data.channel_identifier > channel_identifier
-                )
-
-                if was_channel_gone:
+                if detail.state < ChannelState.CLOSED:
                     msg = (
-                        f"The provided channel identifier does not match the value "
-                        f"on-chain at the block the update transfer was mined ({mining_block}). "
-                        f"provided_channel_identifier={channel_identifier}, "
-                        f"onchain_channel_identifier={channel_data.channel_identifier}"
+                        f"cannot call update_transfer channel has not been closed yet. "
+                        f"current_state={detail.state}"
+                    )
+                    raise RaidenUnrecoverableError(msg)
+
+                if detail.state >= ChannelState.SETTLED:
+                    msg = (
+                        f"cannot call update_transfer channel has been settled already. "
+                        f"current_state={detail.state}"
                     )
                     raise RaidenRecoverableError(msg)
 
-                if channel_data.state >= ChannelState.SETTLED:
-                    # This should never happen if the settlement window and gas
-                    # price estimation is done properly.
-                    #
-                    # This is a race condition that cannot be prevented,
-                    # therefore it is a recoverable error.
-                    msg = "Channel was already settled when update transfer was mined."
-                    raise RaidenRecoverableError(msg)
+                if detail.settle_block_number < failed_at_blocknumber:
+                    raise RaidenRecoverableError(
+                        "update_transfer transation sent after settlement window"
+                    )
 
-                if channel_data.settle_block_number < mining_block:
-                    # The channel is cleared from the smart contract's storage
-                    # on call to settle, this means that settle_block_number
-                    # may be zero, therefore this check must be done after the
-                    # channel's state check.
-                    #
-                    # This is a race condition that cannot be prevented,
-                    # therefore it is a recoverable error.
-                    msg = "update transfer was mined after the settlement " "window."
-                    raise RaidenRecoverableError(msg)
-
+                # At this point it is known the channel is CLOSED on block
+                # `failed_at_blockhash`
                 partner_details = self._detail_participant(
                     channel_identifier=channel_identifier,
                     participant=partner,
-                    partner=lc_address,
-                    block_identifier=mining_block,
+                    partner=self.node_address,
+                    block_identifier=failed_at_blockhash,
                 )
-                if partner_details.nonce != nonce:
-                    # A higher value should be impossible because a signature
-                    # from this node is necessary and this node should send the
-                    # partner's balance proof with the highest nonce
-                    #
-                    # A lower value means some unexpected failure.
-                    msg = (
-                        f"update transfer failed, the on-chain nonce is higher then our expected "
-                        f"value expected={nonce} actual={partner_details.nonce}"
+
+                if not partner_details.is_closer:
+                    raise RaidenUnrecoverableError(
+                        "update_transfer cannot be sent if the partner did not close the channel"
                     )
-                    raise RaidenUnrecoverableError(msg)
 
-                if channel_data.state < ChannelState.CLOSED:
-                    msg = (
-                        f"The channel state changed unexpectedly. "
-                        f"block=({mining_block}) onchain_state={channel_data.state}"
-                    )
-                    raise RaidenUnrecoverableError(msg)
-
-                raise RaidenUnrecoverableError("update transfer failed for an unknown reason")
-
+                raise RaidenUnrecoverableError("update_transfer failed for an unknown reason")
+        except Exception:
+            log.info("An error occurred trying to update the non closing balance proof for channel id " +
+                     str(channel_identifier), **log_details)
+            raise
         else:
-            # The transaction would have failed if sent, figure out why.
-
-            # The latest block can not be used reliably because of reorgs,
-            # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
-            failed_at_blockhash = encode_hex(failed_at["hash"])
-            failed_at_blocknumber = failed_at["number"]
-
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
-                transaction_name="updateNonClosingBalanceProof",
-                address=self.node_address,
-                transaction_executed=False,
-                required_gas=GAS_REQUIRED_FOR_UPDATE_BALANCE_PROOF,
-                block_identifier=failed_at_blocknumber,
-            )
-
-            detail = self._detail_channel(
-                participant1=self.node_address,
-                participant2=partner,
-                block_identifier=failed_at_blockhash,
-                channel_identifier=channel_identifier,
-            )
-
-            if detail.state < ChannelState.CLOSED:
-                msg = (
-                    f"cannot call update_transfer channel has not been closed yet. "
-                    f"current_state={detail.state}"
-                )
-                raise RaidenUnrecoverableError(msg)
-
-            if detail.state >= ChannelState.SETTLED:
-                msg = (
-                    f"cannot call update_transfer channel has been settled already. "
-                    f"current_state={detail.state}"
-                )
-                raise RaidenRecoverableError(msg)
-
-            if detail.settle_block_number < failed_at_blocknumber:
-                raise RaidenRecoverableError(
-                    "update_transfer transation sent after settlement window"
-                )
-
-            # At this point it is known the channel is CLOSED on block
-            # `failed_at_blockhash`
-            partner_details = self._detail_participant(
-                channel_identifier=channel_identifier,
-                participant=partner,
-                partner=self.node_address,
-                block_identifier=failed_at_blockhash,
-            )
-
-            if not partner_details.is_closer:
-                raise RaidenUnrecoverableError(
-                    "update_transfer cannot be sent if the partner did not close the channel"
-                )
-
-            raise RaidenUnrecoverableError("update_transfer failed for an unknown reason")
-
-        log.info("updateNonClosingBalanceProof successful", **log_details)
+            log.info("updateNonClosingBalanceProof successful", **log_details)
+        finally:
+            # if an error occurred we need to delete the non closing balance proof from the database
+            log.info("Deleting non closing balance proof for channel id " + str(channel_identifier), **log_details)
+            raiden.wal.storage.delete_light_client_non_closing_balance_proof(channel_id=channel_identifier)
 
     def update_transfer(
         self,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -438,10 +438,12 @@ class RaidenEventHandler(EventHandler):
     ):
         balance_proof = channel_update_event.balance_proof
 
-        if balance_proof:
+        # checking that this balance proof exists on the database
+        db_balance_proof = raiden.wal.storage.get_latest_light_client_non_closing_balance_proof(channel_id=balance_proof.channel_identifier)
+
+        if db_balance_proof:
             canonical_identifier = balance_proof.canonical_identifier
             channel = raiden.chain.payment_channel(canonical_identifier=canonical_identifier)
-            partner_address = None
             if channel_update_event.lc_address == channel.participant2:
                 partner_address = channel.participant1
             else:
@@ -455,6 +457,7 @@ class RaidenEventHandler(EventHandler):
                 partner_signature=balance_proof.signature,
                 signature=channel_update_event.lc_bp_signature,
                 block_identifier=channel_update_event.triggered_by_block_hash,
+                raiden=raiden
             )
 
     @staticmethod

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -1396,6 +1396,10 @@ class SQLiteStorage:
         )
         return cursor.fetchone()
 
+    def delete_light_client_non_closing_balance_proof(self, channel_id):
+        with self.write_lock, self.conn:
+            self.conn.execute("DELETE FROM light_client_balance_proof WHERE channel_id = ?", (channel_id,))
+
     def get_light_client_payment_locked_transfer(self, payment_identifier):
         cursor = self.conn.cursor()
         cursor.execute(
@@ -1583,10 +1587,7 @@ class SerializedSQLiteStorage(SQLiteStorage):
 
     def delete_light_client(self, address):
         with self.write_lock, self.conn:
-            cursor = self.conn.execute("DELETE FROM client WHERE address = ?", (address,))
-            last_id = cursor.lastrowid
-
-        return last_id
+            self.conn.execute("DELETE FROM client WHERE address = ?", (address,))
 
     def flag_light_client_as_pending_for_deletion(self, address):
         with self.write_lock, self.conn:

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -139,7 +139,7 @@ def handle_balance(
 
 def handle_closed(
     token_network_state: TokenNetworkState,
-    state_change: ContractReceiveChannelClosed,
+    state_change: Union[ContractReceiveChannelClosed, ContractReceiveChannelClosedLight],
     block_number: BlockNumber,
     block_hash: BlockHash,
 ) -> TransitionResult:


### PR DESCRIPTION
* Adding try catch to manage the way we update the non closing balance proof to delete it when it fails or it's successful

* Adding the delete non closing balance proof method to delete the balance proof by channel id

* Checking if the balance proof exists on the db before sending that again if it's in the state of the event