### PR TITLE
RLP-656/Added default value for signed_tx

### DIFF
--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -188,9 +188,10 @@ class ActionChannelClose(StateChange):
     """ User is closing an existing channel. """
 
     def __init__(self, canonical_identifier: CanonicalIdentifier,
-                 signed_close_tx: str,
                  participant1: AddressHex,
-                 participant2: AddressHex) -> None:
+                 participant2: AddressHex,
+                 signed_close_tx: str = None
+                 ) -> None:
         self.canonical_identifier = canonical_identifier
         self.signed_close_tx = signed_close_tx
         self.participant1 = participant1


### PR DESCRIPTION
This fixes a bug that was happen when trying to close a channel, it was sending a signed_tx attr and it was not needed. Only needed for LC.

Fix: Assigned default value for signed_tx in ActionChannelClose, when it is a non-lightclient.