### PR TITLE
Feature/RLP-688/Mediated-transfer-LC

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1696,6 +1696,7 @@ class RaidenAPI:
         amount: typing.TokenAmount,
         secrethash: typing.SecretHash
     ) -> HubResponseMessage:
+
         channel_state = views.get_channelstate_for(
             views.state_from_raiden(self.raiden),
             registry_address,
@@ -1703,6 +1704,13 @@ class RaidenAPI:
             creator_address,
             partner_address,
         )
+        if not channel_state:
+            channel_state = views.get_channelstate_for(
+                views.state_from_raiden(self.raiden),
+                registry_address,
+                token_address,
+                creator_address,
+            )
         if channel_state:
             chain_state = views.state_from_raiden(self.raiden)
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1704,13 +1704,15 @@ class RaidenAPI:
             creator_address,
             partner_address,
         )
+        #If we dont have a channel with the partner we need to get a channel to try a mediated transfer
         if not channel_state:
-            channel_state = views.get_channelstate_for(
+            channel_state = views.get_first_channelstate(
                 views.state_from_raiden(self.raiden),
                 registry_address,
                 token_address,
                 creator_address,
             )
+
         if channel_state:
             chain_state = views.state_from_raiden(self.raiden)
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1750,7 +1750,7 @@ class RaidenAPI:
                                                     message=locked_transfer, is_signed=False)
             return HubResponseMessage(lcpm_id, LightClientProtocolMessageType.PaymentSuccessful, payment_hub_message)
         else:
-            raise ChannelNotFound("Channel with given partner address doesnt exists")
+            raise ChannelNotFound("Your light client has 0 channels oppened")
 
     def validate_light_client(self, api_key: str):
         """

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -79,7 +79,7 @@ class ChannelsResourceLight(BaseResource):
         this translates to 'get all light channels the node is connected with'
         """
         return self.rest_api.get_channel_list(
-            self.rest_api.raiden_api.raiden.default_registry.addressF
+            self.rest_api.raiden_api.raiden.default_registry.address
         )
 
     @use_kwargs(put_schema, locations=("json",))

--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,5 +1,5 @@
-const backendUrl='http://localhost:5002'; 
-const nodeAddress = '0x1989d9298166ca8b4190e8Bf7A41e9e87CEBee9f'; 
+const backendUrl='http://localhost:5000'; 
+const nodeAddress = '0x0608bc158c0BF6E1898Add061104576d4B127EFC'; 
 const rnsDomain = null 
 const chainEndpoint = 'http://127.0.0.1:4444'; 
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -2,13 +2,13 @@ import random
 
 from eth_utils import to_canonical_address
 
-from raiden.constants import MAXIMUM_PENDING_TRANSFERS
+from raiden.constants import MAXIMUM_PENDING_TRANSFERS, EMPTY_PAYMENT_HASH_INVOICE
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
 from raiden.messages import LockedTransfer, Unlock
 from raiden.settings import DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
-from raiden.transfer.channel import create_sendlockedtransfer
+from raiden.transfer.channel import create_sendlockedtransfer, get_amount_locked, get_next_nonce
 from raiden.transfer.events import EventPaymentSentFailed, EventPaymentSentSuccess
 from raiden.transfer.mediated_transfer.events import (
     CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
@@ -49,7 +49,7 @@ from raiden.utils.typing import (
     Secret,
     SecretHash,
     TokenNetworkID,
-    AddressHex)
+    AddressHex, TokenAmount, TokenNetworkAddress, TargetAddress, InitiatorAddress)
 
 
 def events_for_unlock_base(
@@ -232,6 +232,84 @@ def next_channel_from_routes(
 
     return None
 
+
+def create_new_route_light(
+    channelidentifiers_to_channels: ChannelMap,
+    available_routes: List[RouteState],
+    transfer_description: TransferDescriptionWithoutSecretState,
+    pseudo_random_generator: random.Random,
+    block_number: BlockNumber,
+) -> TransitionResult[InitiatorTransferState]:
+    channel_state = next_channel_from_routes(
+        available_routes=available_routes,
+        channelidentifiers_to_channels=channelidentifiers_to_channels,
+        transfer_amount=transfer_description.amount,
+        initiator=to_canonical_address(transfer_description.initiator)
+    )
+    events: List[Event] = list()
+    if channel_state is None:
+        if not available_routes:
+            reason = "there is no route available"
+        else:
+            reason = "none of the available routes could be used"
+        # TODO mmartinez handle persistance with status failure?
+        transfer_failed = EventPaymentSentFailed(
+            payment_network_identifier=transfer_description.payment_network_identifier,
+            token_network_identifier=transfer_description.token_network_identifier,
+            identifier=transfer_description.payment_identifier,
+            target=transfer_description.target,
+            reason=reason,
+        )
+        events.append(transfer_failed)
+
+        initiator_state = None
+    else:
+        # Todo Rodrigo
+        # Necesito crear un esqueleto de locked transfer aqui con los datos que tengo, para que el usuario agregue los datos restantes (en este caso seria un secrethash)
+        # Este secrethash sera usado para crear el objet Lock dentro del locked transfer, pero como aun aqui no tenemos interaccion con el LC...
+        message_identifier = message_identifier_from_prng(pseudo_random_generator)
+        amount = transfer_description.amount
+        creator_address = transfer_description.initiator
+        partner_address = transfer_description.target
+        payment_identifier = transfer_description.payment_identifier
+
+        our_balance_proof = channel_state.our_state.balance_proof
+        if our_balance_proof:
+            transferred_amount = our_balance_proof.transferred_amount
+        else:
+            transferred_amount = TokenAmount(0)
+        locked_amount = TokenAmount(get_amount_locked(channel_state.our_state) + amount)
+
+        locked_transfer = LockedTransfer(
+            chain_id=channel_state.canonical_identifier.chain_identifier,
+            message_identifier=message_identifier,
+            payment_identifier=payment_identifier,
+            payment_hash_invoice=EMPTY_PAYMENT_HASH_INVOICE,
+            nonce=get_next_nonce(channel_state.our_state),
+            token_network_address=TokenNetworkAddress(channel_state.canonical_identifier.token_network_address),
+            token=channel_state.token_address,
+            channel_identifier=channel_state.canonical_identifier.channel_identifier,
+            transferred_amount=transferred_amount,
+            locked_amount=locked_amount,
+            recipient=channel_state.partner_state.address,
+            locksroot=None,
+            lock=None,
+            target=TargetAddress(partner_address),
+            initiator=InitiatorAddress(creator_address),
+            fee=0,
+        )
+
+        # Persist the light_client_protocol_message associated
+        order = 1
+        store_signed_lt = StoreMessageEvent(locked_transfer.message_identifier,
+                                            locked_transfer.payment_identifier,
+                                            order,
+                                            locked_transfer,
+                                            False,
+                                            LightClientProtocolMessageType.PaymentSuccessful)
+        events.append(store_signed_lt)
+
+    return TransitionResult(initiator_state, events)
 
 def try_new_route_light(
     channelidentifiers_to_channels: ChannelMap,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -13,7 +13,7 @@ from raiden.transfer.mediated_transfer.state import (
     InitiatorPaymentState,
     InitiatorTransferState,
     TransferDescriptionWithSecretState,
-)
+    TransferDescriptionWithoutSecretState)
 from raiden.transfer.mediated_transfer.state_change import (
     ActionInitInitiator,
     ReceiveLockExpired,
@@ -388,24 +388,104 @@ def handle_transferreroute_light(
     storage
 ) -> TransitionResult[InitiatorPaymentState]:
     events: List[Event] = []
-    #TODO Rodrigo apply logic for refund here
     try:
         initiator_state = payment_state.initiator_transfers.get(state_change.transfer.lock.secrethash)
-        channel_identifier = state_change.routes[0].channel_identifier
+        channel_identifier = initiator_state.channel_identifier
         channel_state = channelidentifiers_to_channels[initiator_state.transfer.initiator].get(channel_identifier)
     except KeyError:
         return TransitionResult(payment_state, list())
-    # if len(state_change.routes) > 0:
-    #     channel_state = views.get_channelstate_for(
-    #         views.state_from_raiden(self.raiden),
-    #         registry_address,
-    #         token_address,
-    #         creator_address,
-    #         state_change.routes[0].channel_identifier,
-    #     )
+
+    refund_transfer = state_change.transfer
+    original_transfer = initiator_state.transfer
+
+    is_valid_lock = (
+        refund_transfer.lock.secrethash == original_transfer.lock.secrethash
+        and refund_transfer.lock.amount == original_transfer.lock.amount
+        and refund_transfer.lock.expiration == original_transfer.lock.expiration
+    )
+
+    is_valid_refund = channel.refund_transfer_matches_transfer(refund_transfer, original_transfer)
+    is_valid, channel_events, _, _ = channel.handle_receive_lockedtransfer(
+        channel_state, refund_transfer, None
+    )
+
+    if not is_valid_lock or not is_valid_refund or not is_valid:
+        return TransitionResult(payment_state, list())
+
+    events: List[Event] = []
+    events.extend(channel_events)
+
+    old_description = initiator_state.transfer_description
+    transfer_description = TransferDescriptionWithoutSecretState(
+        payment_network_identifier=old_description.payment_network_identifier,
+        payment_identifier=old_description.payment_identifier,
+        payment_hash_invoice=old_description.payment_hash_invoice,
+        amount=old_description.amount,
+        token_network_identifier=old_description.token_network_identifier,
+        allocated_fee=old_description.allocated_fee,
+        initiator=old_description.initiator,
+        target=old_description.target,
+    )
+
+    sub_iteration = maybe_try_new_route_light(
+        payment_state=payment_state,
+        initiator_state=initiator_state,
+        transfer_description=transfer_description,
+        available_routes=state_change.routes,
+        channelidentifiers_to_channels=channelidentifiers_to_channels,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+    )
+
+    events.extend(sub_iteration.events)
+
+    if sub_iteration.new_state is None:
+        # Here we don't delete the initiator state, but instead let it live.
+        # It will be deleted when the lock expires. We do that so that we
+        # still have an initiator payment task around to process the
+        # LockExpired message that our partner will send us.
+        # https://github.com/raiden-network/raiden/issues/3146#issuecomment-447378046
+        return TransitionResult(payment_state, events)
 
     return TransitionResult(payment_state, events)
 
+
+def maybe_try_new_route_light(
+    payment_state: InitiatorPaymentState,
+    initiator_state: InitiatorTransferState,
+    transfer_description: TransferDescriptionWithoutSecretState,
+    available_routes: List[RouteState],
+    channelidentifiers_to_channels: ChannelMap,
+    pseudo_random_generator: random.Random,
+    block_number: BlockNumber,
+) -> TransitionResult[InitiatorPaymentState]:
+    events: List[Event] = list()
+    if can_cancel(initiator_state):
+        cancel_events = cancel_current_route(payment_state, initiator_state)
+
+        sub_iteration = initiator.create_new_route_light(
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            available_routes=available_routes,
+            transfer_description=transfer_description,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+        )
+
+        events.extend(cancel_events)
+        events.extend(sub_iteration.events)
+
+        if sub_iteration.new_state is None:
+            # Here we don't delete the initiator state, but instead let it live.
+            # It will be deleted when the lock expires. We do that so that we
+            # still have an initiator payment task around to process the
+            # LockExpired message that our partner will send us.
+            # https://github.com/raiden-network/raiden/issues/3146#issuecomment-447378046
+            return TransitionResult(payment_state, events)
+
+        new_transfer = sub_iteration.new_state.transfer
+        payment_state.initiator_transfers[new_transfer.lock.secrethash] = sub_iteration.new_state
+
+    return TransitionResult(payment_state, events)
 
 def handle_lock_expired(
     payment_state: InitiatorPaymentState,

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -303,6 +303,43 @@ class ReceiveTransferCancelRoute(BalanceProofStateChange):
             and super().__eq__(other)
         )
 
+class ReceiveTransferCancelRouteLight(BalanceProofStateChange):
+    """ A mediator sends us a refund due to a failed route """
+
+    def __init__(
+        self,
+        balance_proof: BalanceProofSignedState,
+        transfer: LockedTransferSignedState,
+        sender: Address,
+    ) -> None:
+        super().__init__(balance_proof)
+        self.transfer = transfer
+        self.sender = sender
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "balance_proof": self.balance_proof,
+            "transfer": self.transfer,
+            "sender": to_checksum_address(self.sender),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ReceiveTransferCancelRouteLight":
+        return cls(
+            balance_proof=data["balance_proof"],
+            transfer=data["transfer"],
+            sender=to_canonical_address(data["sender"]),
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ReceiveTransferCancelRouteLight)
+            and self.balance_proof == other.balance_proof
+            and self.transfer == other.transfer
+            and self.sender == other.sender
+            and super().__eq__(other)
+        )
+
 
 class ReceiveLockExpired(BalanceProofStateChange):
     """ A LockExpired message received. """
@@ -658,12 +695,50 @@ class ActionTransferReroute(BalanceProofStateChange):
             "balance_proof": self.balance_proof,
         }
 
+class ActionTransferRerouteLight(BalanceProofStateChange):
+    """ A RefundTransfer message received by the initiator will cancel the current
+    route.
+    """
+
+    def __init__(
+        self, routes: List[RouteState], transfer: LockedTransferSignedState
+    ) -> None:
+        if not isinstance(transfer, LockedTransferSignedState):
+            raise ValueError("transfer must be an instance of LockedTransferSignedState")
+
+        super().__init__(transfer.balance_proof)
+        self.transfer = transfer
+        self.routes = routes
+
+    def __repr__(self) -> str:
+        return "<ActionTransferRerouteLight sender:{} transfer:{}>".format(
+            pex(self.sender), self.transfer
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ActionTransferRerouteLight)
+            and self.sender == other.sender
+            and self.transfer == other.transfer
+            and self.routes == other.routes
+            and super().__eq__(other)
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "routes": self.routes,
+            "transfer": self.transfer,
+            "balance_proof": self.balance_proof,
+        }
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ActionTransferReroute":
+    def from_dict(cls, data: Dict[str, Any]) -> "ActionTransferRerouteLight":
         instance = cls(
             routes=data["routes"],
             transfer=data["transfer"],
-            secret=Secret(deserialize_bytes(data["secret"])),
         )
         return instance
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -286,7 +286,7 @@ def handle_send_secret_reveal_light(
     message_identifier = state_change.reveal_secret.message_identifier
     transfer = target_state.transfer
     # The recipiant is the initiator of the payment cause the light client is the target of the payment
-    recipient = transfer.initiator
+    recipient = state_change.receiver
     revealsecret = SendSecretRevealLight(
         sender=Address(state_change.sender),
         recipient=Address(recipient),

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -951,7 +951,7 @@ def handle_state_change(
         iteration = handle_init_target(chain_state, state_change, storage, chain_state.our_address)
     elif type(state_change) == ActionInitTargetLight:
         assert isinstance(state_change, ActionInitTargetLight), MYPY_ANNOTATION
-        iteration = handle_init_target(chain_state, state_change, storage, state_change.transfer.initiator)
+        iteration = handle_init_target(chain_state, state_change, storage, state_change.transfer.target)
     elif type(state_change) == ActionUpdateTransportAuthData:
         assert isinstance(state_change, ActionUpdateTransportAuthData), MYPY_ANNOTATION
         iteration = handle_update_transport_authdata(chain_state, state_change)

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -292,20 +292,32 @@ def get_channelstate_for(
     if token_network and creator_address in token_network.channelidentifiers_to_channels or \
         token_network and partner_address in token_network.channelidentifiers_to_channels:
         channels = []
-        for channel_id in token_network.partneraddresses_to_channelidentifiers[partner_address]:
+        if partner_address:
+            for channel_id in token_network.partneraddresses_to_channelidentifiers[partner_address]:
 
-            if creator_address in token_network.channelidentifiers_to_channels:
-                channel = token_network.channelidentifiers_to_channels[creator_address].get(channel_id)
+                if creator_address in token_network.channelidentifiers_to_channels:
+                    channel = token_network.channelidentifiers_to_channels[creator_address].get(channel_id)
 
-            if channel is None and partner_address in token_network.channelidentifiers_to_channels:
-                # Check if partner address had a open channel, can be a hub node.
-                channel = token_network.channelidentifiers_to_channels[partner_address].get(channel_id)
-                address_to_get_channel_state = partner_address
+                if channel is None and partner_address in token_network.channelidentifiers_to_channels:
+                    # Check if partner address had a open channel, can be a hub node.
+                    channel = token_network.channelidentifiers_to_channels[partner_address].get(channel_id)
+                    address_to_get_channel_state = partner_address
 
-            if channel is not None:
-                if channel.close_transaction is None or channel.close_transaction.result != 'success':
-                    channels.append(token_network.channelidentifiers_to_channels[address_to_get_channel_state][channel_id])
-            channel = None
+                if channel is not None:
+                    if channel.close_transaction is None or channel.close_transaction.result != 'success':
+                        channels.append(token_network.channelidentifiers_to_channels[address_to_get_channel_state][channel_id])
+                channel = None
+        else:
+            for channel_id in token_network.partneraddresses_to_channelidentifiers[creator_address]:
+
+                if creator_address in token_network.channelidentifiers_to_channels:
+                    channel = token_network.channelidentifiers_to_channels[creator_address].get(channel_id)
+
+                if channel is not None:
+                    if channel.close_transaction is None or channel.close_transaction.result != 'success':
+                        channels.append(
+                            token_network.channelidentifiers_to_channels[address_to_get_channel_state][channel_id])
+                channel = None
 
         states = filter_channels_by_status(channels, [CHANNEL_STATE_UNUSABLE])
         # If multiple channel states are found, return the last one.


### PR DESCRIPTION
Fixes mediated transfer between a LC and a Lumino node.
Errors, bugs and features that was not letting the HUB make the mediated transfer, here's the description:

- LC was not able to make a mediated transfer
**Problem**: At the creation of the locked transfer message (First message of the protocol), it was checking if the LC had a channel with the given partner
**Solution**: Now if it can get the channel with the partner, it gets the first channel and tries a mediated transfer
- LC was not able to receive a mediated transfer
**Problem**: Some messages of the protocol was trying to be sended to wrong addresses
**Solution**: Changed variables that was confusing the addresses, and sending the message wrongly. 