### PR TITLE
Feature/internal-routing-mediation-fees

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,7 +1,7 @@
 import structlog
 from eth_utils import to_checksum_address
 
-from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
 from raiden.exceptions import InvalidSettleTimeout
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.discovery import Discovery
@@ -94,6 +94,8 @@ class App:  # pylint: disable=too-few-public-methods
         transport,
         raiden_event_handler,
         message_handler,
+        routing_mode: RoutingMode,
+
         discovery: Discovery = None,
         user_deposit: UserDeposit = None,
     ):
@@ -107,6 +109,7 @@ class App:  # pylint: disable=too-few-public-methods
             transport=transport,
             raiden_event_handler=raiden_event_handler,
             message_handler=message_handler,
+            routing_mode=routing_mode,
             config=config,
             discovery=discovery,
             user_deposit=user_deposit,

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -101,8 +101,9 @@ class Environment(Enum):
 class RoutingMode(Enum):
     """Routing mode configuration that can be chosen on the command line"""
 
-    BASIC = "basic"
     PFS = "pfs"
+    LOCAL = "local"
+    PRIVATE = "private"
 
 
 GAS_REQUIRED_FOR_CREATE_ERC20_TOKEN_NETWORK = 3_234_716

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -21,7 +21,7 @@ from raiden.constants import (
     SECRET_LENGTH,
     SNAPSHOT_STATE_CHANGES_COUNT,
     Environment,
-)
+    RoutingMode)
 from raiden.exceptions import (
     InvalidAddress,
     InvalidDBData,
@@ -275,6 +275,7 @@ class RaidenService(Runnable):
         transport,
         raiden_event_handler,
         message_handler,
+        routing_mode: RoutingMode,
         config,
         discovery=None,
         user_deposit=None,
@@ -289,6 +290,7 @@ class RaidenService(Runnable):
         self.default_one_to_n_address = default_one_to_n_address
         self.default_secret_registry = default_secret_registry
         self.default_service_registry = default_service_registry
+        self.routing_mode = routing_mode
         self.config = config
 
         self.signer: Signer = LocalSigner(self.chain.client.privkey)

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -137,27 +137,17 @@ def check_smart_contract_addresses(
 
 
 def check_pfs_configuration(
-    routing_mode: RoutingMode,
-    environment_type: Environment,
-    service_registry: Optional[ServiceRegistry],
-    pathfinding_service_address: str,
+    service_registry: Optional[ServiceRegistry], pathfinding_service_address: str
 ) -> None:
-    if routing_mode == RoutingMode.PFS:
-        if environment_type == Environment.PRODUCTION:
-            click.secho(
-                "Requested production mode and PFS routing mode. This is not supported", fg="red"
-            )
-            sys.exit(1)
-
-        if not service_registry and not pathfinding_service_address:
-            click.secho(
-                "Requested PFS routing mode but no service registry or no specific pathfinding "
-                " service address is provided. Please provide it via either the "
-                "--service-registry-contract-address or the --pathfinding-service-address "
-                "argument",
-                fg="red",
-            )
-            sys.exit(1)
+    if not service_registry and not pathfinding_service_address:
+        click.secho(
+            "Requested PFS routing mode but no service registry or no specific pathfinding "
+            " service address is provided. Please provide it via either the "
+            "--service-registry-contract-address or the --pathfinding-service-address "
+            "argument",
+            fg="red",
+        )
+        sys.exit(1)
 
 
 def check_synced(blockchain_service: BlockChainService) -> None:

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -7,7 +7,7 @@ from requests.exceptions import ConnectTimeout
 from web3 import Web3
 
 from raiden.accounts import AccountManager
-from raiden.constants import SQLITE_MIN_REQUIRED_VERSION, Environment, RoutingMode
+from raiden.constants import SQLITE_MIN_REQUIRED_VERSION, Environment
 from raiden.exceptions import EthNodeCommunicationError, EthNodeInterfaceError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.service_registry import ServiceRegistry

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -233,11 +233,12 @@ def options(func):
                 "--routing-mode",
                 help=(
                     "Specify the routing mode to be used.\n"
-                    '"basic": use local routing\n'
                     '"pfs": use the path finding service\n'
+                    '"local": use local routing, but send updates to the PFS\n'
+                    '"private": use local routing and don\'t send updates to the PFS\n'
                 ),
                 type=EnumChoiceType(RoutingMode),
-                default=RoutingMode.BASIC.value,
+                default=RoutingMode.PFS.value,
                 show_default=True,
             ),
             option(
@@ -632,6 +633,7 @@ def smoketest(ctx, debug, eth_client):
         port = next(free_port_generator)
 
         args["api_address"] = "localhost:" + str(port)
+        args["routing_mode"] = RoutingMode.PRIVATE
 
         if args["transport"] == "udp":
             with SocketFactory("127.0.0.1", port, strategy="none") as mapped_socket:

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -217,7 +217,8 @@ def setup_proxies_or_exit(
 
     if routing_mode == RoutingMode.PFS:
         check_pfs_configuration(
-            routing_mode, environment_type, service_registry, pathfinding_service_address
+            service_registry=service_registry,
+            pathfinding_service_address=pathfinding_service_address,
         )
 
         pfs_config = configure_pfs_or_exit(


### PR DESCRIPTION
**Description**

Includes the features for the first mediation fees MVP: mediation fees with internal routing for normal nodes (excluding light client payments)


**Task list for completion:** 

- Update lumino contracts for pathfinding services support.
- Modify payment method for normal nodes to include fees on LT 
- Modify the rest of the messages that involves fees amounts and the messages handlers (full payment protocol should work) 
- Modify internal routing to set estimated fees
- Update CLI only with the internal routing flags 
- Add the related code with those flags
- Update capacity on deposit
- Split fees into channel in and channel out
- Create test cases for fees
 