### PR TITLE
Updated MarkupSafe to 1.1.0 to fix setuptools incompatibility

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -34,7 +34,7 @@ ipython==4.2.1
 itsdangerous==0.24
 Jinja2==2.10
 lru-dict==1.1.6
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 marshmallow-polyfield==3.2
 marshmallow==2.15.4
 matrix-client==0.3.2


### PR DESCRIPTION
Updated MarkupSafe from 1.0 to 1.1.0

The version was incompatible with setup tools

Related issues: 

- https://github.com/pypa/setuptools/issues/2017
- https://github.com/pallets/markupsafe/issues/57