### PR TITLE
Merge 0.0.4 with master 

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -46,7 +46,7 @@ networkx==2.1
 parsimonious==0.8.0
 pexpect==4.6.0
 pickleshare==0.7.4
-psutil==5.4.7
+psutil==5.6.6
 ptyprocess==0.6.0
 py-geth==2.1.0
 py-solc==3.2.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -34,7 +34,7 @@ ipython==4.2.1
 itsdangerous==0.24
 Jinja2==2.10
 lru-dict==1.1.6
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 marshmallow-polyfield==3.2
 marshmallow==2.15.4
 matrix-client==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ miniupnpc==2.0.2
 mirakuru==1.0.0
 netifaces==0.10.7
 networkx==2.1
-psutil==5.4.7
+psutil==5.6.6
 py-geth==2.1.0
 pysha3==1.0.2
 py-solc==3.2.0


### PR DESCRIPTION
Includes https://github.com/rsksmart/lumino/pull/90

Updates MarkupSafe dependency to fix node installation. 