### PR TITLE
bugfix/RLP-708/multiple-refund-rerouting

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -17,9 +17,7 @@ from raiden.messages import (
     Unlock,
 )
 from raiden.raiden_service import RaidenService
-from raiden.routing import get_best_routes
 from raiden.transfer import views
-from raiden.transfer.architecture import StateChange
 from raiden.transfer.mediated_transfer.state import lockedtransfersigned_from_message
 from raiden.transfer.mediated_transfer.state_change import (
     ReceiveLockExpired,
@@ -151,13 +149,9 @@ class MessageHandler:
         chain_state = views.state_from_raiden(raiden)
         from_transfer = lockedtransfersigned_from_message(message)
 
-        token_network_address = message.token_network_address
-
         role = views.get_transfer_role(
             chain_state=chain_state, secrethash=from_transfer.lock.secrethash
         )
-
-        state_change: StateChange
 
         if role == "initiator":
             old_secret = views.get_transfer_secret(chain_state, from_transfer.lock.secrethash)

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -152,18 +152,6 @@ class MessageHandler:
         from_transfer = lockedtransfersigned_from_message(message)
 
         token_network_address = message.token_network_address
-        # FIXME: Shouldn't request routes here
-        routes, _ = get_best_routes(
-            chain_state=chain_state,
-            token_network_id=TokenNetworkID(token_network_address),
-            one_to_n_address=raiden.default_one_to_n_address,
-            from_address=InitiatorAddress(raiden.address),
-            to_address=from_transfer.target,
-            amount=PaymentAmount(from_transfer.lock.amount),  # FIXME: mypy; deprecated by #3863
-            previous_address=message.sender,
-            config=raiden.config,
-            privkey=raiden.privkey,
-        )
 
         role = views.get_transfer_role(
             chain_state=chain_state, secrethash=from_transfer.lock.secrethash
@@ -189,7 +177,6 @@ class MessageHandler:
             # (and generate a new secret)
             if is_secret_known:
                 state_change = ActionTransferReroute(
-                    routes=routes,
                     transfer=from_transfer,
                     secret=random_secret()
                 )

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -29,8 +29,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import balanceproof_from_envelope
 from raiden.transfer.state_change import ReceiveDelivered, ReceiveProcessed, ReceiveUnlock, ReceiveUnlockLight
 from raiden.utils import pex, random_secret
-from raiden.utils.typing import MYPY_ANNOTATION, InitiatorAddress, PaymentAmount, TokenNetworkID
-
+from raiden.utils.typing import MYPY_ANNOTATION
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -175,7 +175,7 @@ class MessageHandler:
                     secret=random_secret()
                 )
         else:
-            state_change = ReceiveTransferRefund(transfer=from_transfer, routes=routes)
+            state_change = ReceiveTransferRefund(transfer=from_transfer)
 
         raiden.handle_and_track_state_change(state_change)
 

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -48,7 +48,7 @@ def test_initiator_task_view():
         transfer=transfer,
         revealsecret=None,
     )
-    payment_state = InitiatorPaymentState({secrethash: transfer_state})
+    payment_state = InitiatorPaymentState(routes=[], initiator_transfers={secrethash: transfer_state})
     task = InitiatorTask(
         token_network_identifier=factories.UNIT_TOKEN_NETWORK_ADDRESS, manager_state=payment_state
     )

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -167,10 +167,9 @@ def test_get_state_change_with_balance_proof():
         balance_proof=make_signed_balance_proof_from_counter(counter),
     )
     transfer_refund = ReceiveTransferRefund(
-        transfer=make_signed_transfer_from_counter(counter), routes=list()
+        transfer=make_signed_transfer_from_counter(counter)
     )
     transfer_refund_cancel_route = ActionTransferReroute(
-        routes=list(),
         transfer=make_signed_transfer_from_counter(counter),
         secret=sha3(factories.make_secret(next(counter))),
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -439,7 +439,7 @@ def test_refund_transfer_next_route():
 
 
     state_change = ActionTransferReroute(
-        routes=channel_set.get_routes(), transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(
@@ -490,7 +490,7 @@ def test_refund_transfer_no_more_routes():
     )
 
     state_change = ActionTransferReroute(
-        routes=setup.available_routes, transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(
@@ -1143,7 +1143,7 @@ def test_secret_reveal_cancel_other_transfers():
     assert channel_set.get_sub_channel(0).partner_state.address == refund_address
 
     state_change = ActionTransferReroute(
-        routes=channel_set.get_routes(), transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(
@@ -1249,7 +1249,7 @@ def test_refund_after_secret_request():
     )
 
     state_change = ActionTransferReroute(
-        routes=setup.available_routes, transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(
@@ -1308,7 +1308,7 @@ def test_clearing_payment_state_on_lock_expires_with_refunded_transfers():
     )
 
     state_change = ActionTransferReroute(
-        routes=channel_set.get_routes(), transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(
@@ -1434,14 +1434,14 @@ def test_initiator_manager_drops_invalid_state_changes():
     channel_set = factories.make_channel_set_from_amounts(amounts=[10], token_address=factories.UNIT_TRANSFER_DESCRIPTION.initiator)
     transfer = factories.create(factories.LockedTransferSignedStateProperties())
     secret = factories.UNIT_SECRET
-    cancel_route = ActionTransferReroute(channel_set.get_routes(), transfer, secret)
+    cancel_route = ActionTransferReroute(transfer, secret)
 
     balance_proof = factories.create(factories.BalanceProofSignedStateProperties())
     lock_expired = ReceiveLockExpired(balance_proof, factories.UNIT_SECRETHASH, 1)
 
     prng = random.Random()
     for state_change in (cancel_route, lock_expired):
-        state = InitiatorPaymentState(initiator_transfers=dict())
+        state = InitiatorPaymentState(routes=[], initiator_transfers=dict())
         iteration = initiator_manager.state_transition(
             payment_state=state,
             state_change=lock_expired,
@@ -1458,7 +1458,7 @@ def test_initiator_manager_drops_invalid_state_changes():
             revealsecret=None,
         )
         state = InitiatorPaymentState(
-            initiator_transfers={factories.UNIT_SECRETHASH: initiator_state}
+            routes=[], initiator_transfers={factories.UNIT_SECRETHASH: initiator_state}
         )
         iteration = initiator_manager.state_transition(
             payment_state=state,
@@ -1470,7 +1470,7 @@ def test_initiator_manager_drops_invalid_state_changes():
         assert_dropped(iteration, state, "unknown channel identifier")
 
     transfer2 = factories.create(factories.LockedTransferSignedStateProperties(amount=2))
-    cancel_route2 = ActionTransferReroute(channel_set.get_routes(), transfer2, secret)
+    cancel_route2 = ActionTransferReroute(transfer2, secret)
     iteration = initiator_manager.state_transition(
         state, cancel_route2, channel_set.channel_map, prng, 1
     )
@@ -1519,7 +1519,7 @@ def test_regression_payment_unlock_failed_event_must_be_emitted_only_once():
     )
 
     state_change = ActionTransferReroute(
-        routes=channel_set.get_routes(), transfer=refund_transfer, secret=random_secret()
+        transfer=refund_transfer, secret=random_secret()
     )
 
     iteration = initiator_manager.state_transition(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -158,7 +158,7 @@ def test_regression_send_refund():
     # All three channels have been used
     routes = []
 
-    refund_state_change = ReceiveTransferRefund(transfer=received_transfer, routes=routes)
+    refund_state_change = ReceiveTransferRefund(transfer=received_transfer)
 
     iteration = mediator.handle_refundtransfer(
         mediator_state=mediator_state,
@@ -335,6 +335,8 @@ def test_regression_mediator_task_no_routes():
         token_network_identifier=channel_set.get_sub_channel(0).token_network_identifier,
         channel_identifier=channel_set.get_sub_channel(0).identifier,
         recipient=channel_set.get_sub_channel(0).our_state.address,
+        payment_identifier=payer_transfer.payment_identifier,
+        is_light_channel=False
     )
     assert send_lock_expired
     lock_expired_message = message_from_sendevent(send_lock_expired)

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -2,7 +2,7 @@ import random
 
 from eth_utils import keccak
 
-from raiden.transfer import channel
+from raiden.transfer import channel, routes
 from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.events import EventPaymentSentFailed
 from raiden.transfer.mediated_transfer import initiator
@@ -216,6 +216,7 @@ def handle_init(
         events = sub_iteration.events
         if sub_iteration.new_state:
             payment_state = InitiatorPaymentState(
+                routes=state_change.routes,
                 initiator_transfers={
                     sub_iteration.new_state.transfer.lock.secrethash: sub_iteration.new_state
                 }
@@ -241,6 +242,7 @@ def handle_init_light(
         events = sub_iteration.events
         if sub_iteration.new_state:
             payment_state = InitiatorPaymentState(
+                routes=state_change.routes,
                 initiator_transfers={
                     sub_iteration.new_state.transfer.lock.secrethash: sub_iteration.new_state
                 }
@@ -331,6 +333,10 @@ def handle_transferreroute(
     events: List[Event] = []
     events.extend(channel_events)
 
+    filtered_route_states = routes.filter_acceptable_routes(
+        route_states=payment_state.routes, blacklisted_channel_ids=payment_state.cancelled_channels
+    )
+
     old_description = initiator_state.transfer_description
     transfer_description = TransferDescriptionWithSecretState(
         payment_network_identifier=old_description.payment_network_identifier,
@@ -348,7 +354,7 @@ def handle_transferreroute(
         payment_state=payment_state,
         initiator_state=initiator_state,
         transfer_description=transfer_description,
-        available_routes=state_change.routes,
+        available_routes=filtered_route_states,
         channelidentifiers_to_channels=channelidentifiers_to_channels,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1210,7 +1210,7 @@ def handle_refundtransfer(
 
         iteration = mediate_transfer(
             mediator_state,
-            mediator_state_change.routes,
+            mediator_state.routes,
             payer_channel,
             channelidentifiers_to_channels,
             nodeaddresses_to_networkstates,

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -77,9 +77,10 @@ class InitiatorPaymentState(State):
     different secrethash.
     """
 
-    __slots__ = ("cancelled_channels", "initiator_transfers")
+    __slots__ = ("routes","cancelled_channels", "initiator_transfers")
 
-    def __init__(self, initiator_transfers: InitiatorTransfersMap) -> None:
+    def __init__(self, routes: List["RouteState"], initiator_transfers: InitiatorTransfersMap) -> None:
+        self.routes = routes
         self.initiator_transfers = initiator_transfers
         self.cancelled_channels: List[ChannelID] = list()
 
@@ -91,6 +92,7 @@ class InitiatorPaymentState(State):
             isinstance(other, InitiatorPaymentState)
             and self.initiator_transfers == other.initiator_transfers
             and self.cancelled_channels == other.cancelled_channels
+            and self.routes == other.routes
         )
 
     def __ne__(self, other: Any) -> bool:
@@ -100,6 +102,7 @@ class InitiatorPaymentState(State):
         return {
             "initiator_transfers": map_dict(serialize_bytes, identity, self.initiator_transfers),
             "cancelled_channels": self.cancelled_channels,
+            "routes": self.routes
         }
 
     @classmethod
@@ -110,6 +113,7 @@ class InitiatorPaymentState(State):
             )
         )
         restored.cancelled_channels = data["cancelled_channels"]
+        restored.routes = data["routes"]
 
         return restored
 

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -108,12 +108,12 @@ class InitiatorPaymentState(State):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "InitiatorPaymentState":
         restored = cls(
+            routes=data["routes"],
             initiator_transfers=map_dict(
                 deserialize_secret_hash, identity, data["initiator_transfers"]
             )
         )
         restored.cancelled_channels = data["cancelled_channels"]
-        restored.routes = data["routes"]
 
         return restored
 

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -618,7 +618,7 @@ class ActionTransferReroute(BalanceProofStateChange):
     """
 
     def __init__(
-        self, routes: List[RouteState], transfer: LockedTransferSignedState, secret: Secret
+        self, transfer: LockedTransferSignedState, secret: Secret
     ) -> None:
         if not isinstance(transfer, LockedTransferSignedState):
             raise ValueError("transfer must be an instance of LockedTransferSignedState")
@@ -627,7 +627,6 @@ class ActionTransferReroute(BalanceProofStateChange):
 
         super().__init__(transfer.balance_proof)
         self.transfer = transfer
-        self.routes = routes
         self.secrethash = secrethash
         self.secret = secret
 
@@ -641,7 +640,6 @@ class ActionTransferReroute(BalanceProofStateChange):
             isinstance(other, ActionTransferReroute)
             and self.sender == other.sender
             and self.transfer == other.transfer
-            and self.routes == other.routes
             and self.secret == other.secret
             and self.secrethash == other.secrethash
             and super().__eq__(other)
@@ -653,7 +651,6 @@ class ActionTransferReroute(BalanceProofStateChange):
     def to_dict(self) -> Dict[str, Any]:
         return {
             "secret": serialize_bytes(self.secret),
-            "routes": self.routes,
             "transfer": self.transfer,
             "balance_proof": self.balance_proof,
         }
@@ -661,7 +658,6 @@ class ActionTransferReroute(BalanceProofStateChange):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ActionTransferReroute":
         instance = cls(
-            routes=data["routes"],
             transfer=data["transfer"],
             secret=Secret(deserialize_bytes(data["secret"])),
         )

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -667,13 +667,12 @@ class ActionTransferReroute(BalanceProofStateChange):
 class ReceiveTransferRefund(BalanceProofStateChange):
     """ A RefundTransfer message received. """
 
-    def __init__(self, transfer: LockedTransferSignedState, routes: List[RouteState]) -> None:
+    def __init__(self, transfer: LockedTransferSignedState) -> None:
         if not isinstance(transfer, LockedTransferSignedState):
             raise ValueError("transfer must be an instance of LockedTransferSignedState")
 
         super().__init__(transfer.balance_proof)
         self.transfer = transfer
-        self.routes = routes
 
     def __repr__(self) -> str:
         return "<ReceiveTransferRefund sender:{} transfer:{}>".format(
@@ -684,7 +683,6 @@ class ReceiveTransferRefund(BalanceProofStateChange):
         return (
             isinstance(other, ReceiveTransferRefund)
             and self.transfer == other.transfer
-            and self.routes == other.routes
             and super().__eq__(other)
         )
 
@@ -693,14 +691,13 @@ class ReceiveTransferRefund(BalanceProofStateChange):
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "routes": self.routes,
             "transfer": self.transfer,
             "balance_proof": self.balance_proof,
         }
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ReceiveTransferRefund":
-        instance = cls(routes=data["routes"], transfer=data["transfer"])
+        instance = cls(transfer=data["transfer"])
         return instance
 
 

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -1,0 +1,42 @@
+from raiden.transfer.state import (
+    NODE_NETWORK_REACHABLE,
+    RouteState,
+)
+
+from raiden.utils.typing import ChannelID, List, NodeNetworkStateMap
+
+
+def filter_reachable_routes(
+    route_states: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
+) -> List[RouteState]:
+    """ This function makes sure we use reachable routes only. """
+
+    return [
+        route
+        for route in route_states
+        if nodeaddresses_to_networkstates.get(route.node_address) == NODE_NETWORK_REACHABLE
+    ]
+
+
+def filter_acceptable_routes(
+    route_states: List[RouteState], blacklisted_channel_ids: List[ChannelID]
+) -> List[RouteState]:
+    """ Keeps only routes whose forward_channel is not in the list of blacklisted channels """
+
+    return [
+        route for route in route_states if route.channel_identifier not in blacklisted_channel_ids
+    ]
+
+
+def prune_route_table(
+    route_states: List[RouteState], selected_route: RouteState
+) -> List[RouteState]:
+    """ Given a selected route, returns a filtered route table that
+    contains only routes using the same forward channel and removes our own
+    address in the process.
+    """
+    return [
+        RouteState(node_address=rs.node_address, channel_identifier=selected_route.channel_identifier)
+        for rs in route_states
+        if rs.channel_identifier == selected_route.channel_identifier
+    ]


### PR DESCRIPTION
### Description

This PR fixes the mediated transfers for the scenarios where the initiator of the payment must handle a multiple refund re routing. 

### Modifications:

- InitiatorPaymentState has now the routes, so when a refund transfer is received, it can filter the available routes
- Canceled routes are now removed from the ones that can be selected for a re route.

### Acceptance criteria: 

- [x] p2p payments should work
- [ ] p2p light payments should work
- [x] mediated payments should work
- [ ] mediated light payments should work
- [x] mediated payments with multiple refund, when the node is initiator, should work
- [ ] mediated light payments with multiple refund, when the node is initiator, should work
- [x] mediated payments with multiple refund, when the node is mediator, should work 
- [ ] mediated light payments with multiple refund, when the node is mediator, should work 
- [x] all the tests cases should pass

### Notes

This PR will be merged when mediated light client payments implementation ends

