### PR TITLE
Bugfix/rlp 733/deposit light invalid previous deposit

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -633,6 +633,8 @@ class RaidenAPI:
             signed_approval_tx=signed_approval_tx,
             signed_deposit_tx=signed_deposit_tx
         )
+        
+        channel_proxy.swap_participants(creator_address)
 
         waiting.wait_for_participant_newbalance(
             raiden=self.raiden,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -625,6 +625,8 @@ class RaidenAPI:
             canonical_identifier=channel_state.canonical_identifier
         )
 
+        channel_proxy.swap_participants(creator_address)
+
         channel_proxy.set_total_deposit_light(
             total_deposit=total_deposit,
             block_identifier=views.state_from_raiden(self.raiden).block_hash,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -633,8 +633,6 @@ class RaidenAPI:
             signed_approval_tx=signed_approval_tx,
             signed_deposit_tx=signed_deposit_tx
         )
-        
-        channel_proxy.swap_participants(creator_address)
 
         waiting.wait_for_participant_newbalance(
             raiden=self.raiden,

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -321,3 +321,7 @@ class PaymentChannel:
         )
 
         return channel_filter
+
+    def swap_participants(self, forced_participant_1):
+        if forced_participant_1 != self.participant1:
+            self.participant1, self.participant2 = self.participant2, self.participant1


### PR DESCRIPTION
This PR resolves the following bug:

- Partner or light client opens a channel
- The partner deposits on the channel, 0.1 tokens for example
- The light client now deposit some tokens, the hub returns that it must be greater than the previous total deposit (0.1)

The solution:

Since when the payment channel proxy is created, we cannot know if one of the participants is a light client or not (it can be both also), we swap the participants of the payment channel in order to set `participant1=light client address` always.

This way, the deposit preconditions, that are tested against `participant1 ` channel state, are always done against the light client side when it request a new deposit