### PR TITLE
Swap participants on light channel creation to ensure channel_proxy participant1 is always the LC

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -76,6 +76,7 @@ def handle_tokennetwork_new(raiden: "RaidenService", event: Event):
     except AddressWithoutCode:
         log.info("TokenAddress without code, Address: %s", to_checksum_address(token_address))
 
+
 def handle_channel_new(raiden: "RaidenService", event: Event):
     data = event.event_data
     block_number = data["block_number"]
@@ -113,14 +114,19 @@ def handle_channel_new(raiden: "RaidenService", event: Event):
             is_light_channel=is_light_channel
         )
 
-        # Swap our_state and partner_state in order to have the LC from our_side of the channel
         if is_participant1_handled_lc or is_participant2_handled_lc:
             if is_participant1_handled_lc:
                 if participant1 != channel_state.our_state.address:
+                    # Swap our_state and partner_state in order to have the LC from our_side of the channel
                     channel_state.our_state, channel_state.partner_state = channel_state.partner_state, channel_state.our_state
+                # swap channel proxy to ensure proxy.participant1 is the light client
+                channel_proxy.swap_participants(participant1)
             else:
                 if participant2 != channel_state.our_state.address:
+                    # Swap our_state and partner_state in order to have the LC from our_side of the channel
                     channel_state.our_state, channel_state.partner_state = channel_state.partner_state, channel_state.our_state
+                # swap channel proxy to ensure proxy.participant1 is the light client
+                channel_proxy.swap_participants(participant2)
 
         new_channel = ContractReceiveChannelNew(
             transaction_hash=transaction_hash,


### PR DESCRIPTION
This PR resolves the following issue:

1. Partner opens a channel with a light client
2. Partner sends some tokens to the light client
3. Light client closes the channel, therefore a non closing balance proof is sent onchain

The recovered address wasnt correct when handling the close event, that was because the participant1 of the channel proxy was the partner (since it created the channel), but the light client handling code was taking into account that the channelproxy.participant1 was the light client.

The solution:

- Ensure on channel creation, that the participant1 of the channel proxy is the light client, by swapping them.