### PR TITLE
RLP-747 Fixing lumino empty token list crash

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -916,8 +916,7 @@ class RaidenAPI:
         if registry_address and not is_binary_address(registry_address):
             raise InvalidAddress('Expected binary address format for registry in get_channel_list')
 
-        token_addresses_split = token_addresses.split(",") \
-            if token_addresses is not None and token_addresses.__len__() > 0 else list()
+        token_addresses_split = token_addresses.split(",") if token_addresses and len(token_addresses) > 0 else list()
         if isinstance(token_addresses_split, list):
             for token_address in token_addresses_split:
                 self._check_token_address_format(to_canonical_address(token_address))

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -916,7 +916,8 @@ class RaidenAPI:
         if registry_address and not is_binary_address(registry_address):
             raise InvalidAddress('Expected binary address format for registry in get_channel_list')
 
-        token_addresses_split = token_addresses.split(",")
+        token_addresses_split = token_addresses.split(",") \
+            if token_addresses is not None and token_addresses.__len__() > 0 else list()
         if isinstance(token_addresses_split, list):
             for token_address in token_addresses_split:
                 self._check_token_address_format(to_canonical_address(token_address))


### PR DESCRIPTION
This PR fixes the crash on lumino node when the chain doesn't have any token deployed.