### PR TITLE
RLP-765: add remove light client transport functionality

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1770,3 +1770,6 @@ class NodeTransport:
 
     def add_light_client_transport(self, light_client_transport: TransportLayer):
         self.light_client_transports.append(light_client_transport)
+
+    def remove_light_client_transport(self, light_client_transport: TransportLayer):
+        self.light_client_transports.remove(light_client_transport)


### PR DESCRIPTION
This PR adds a method to the `NodeTransport` class to remove light client transport layers.

It is unused as of now, but it's a one-liner that might come in handy later.

Closes [RLP-765](https://jirainfuy.atlassian.net/browse/RLP-765).