### PR TITLE
RLP-766: address normalization

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2072,11 +2072,11 @@ class RestAPI:
         if light_client is not None and light_client["result_code"] == 200:
 
             matrix_light_client_transport_instance = get_matrix_light_client_instance(
-                self.raiden_api.raiden.config["transport"]["matrix"],
+                address=light_client["address"],
+                config=self.raiden_api.raiden.config["transport"]["matrix"],
                 password=light_client["encrypt_signed_password"],
                 display_name=light_client["encrypt_signed_display_name"],
-                seed_retry=light_client["encrypt_signed_seed_retry"],
-                address=light_client["address"])
+                seed_retry=light_client["encrypt_signed_seed_retry"])
 
             self.raiden_api.raiden.start_transport_in_runtime(transport=matrix_light_client_transport_instance,
                                                               chain_state=views.state_from_raiden(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -237,7 +237,7 @@ class RaidenEventHandler(EventHandler):
         mediated_transfer_message = send_locked_transfer_light.signed_locked_transfer
         light_client_address = to_checksum_address(send_locked_transfer_light.signed_locked_transfer.initiator)
         for light_client_transport in raiden.transport.light_client_transports:
-            if light_client_address == light_client_transport._address:
+            if light_client_address == light_client_transport.address:
                 light_client_transport.send_async(send_locked_transfer_light.queue_identifier,
                                                   mediated_transfer_message)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -609,7 +609,7 @@ class RaidenService(Runnable):
             if chain_state.last_node_transport_state_authdata is not None:
                 for client_last_transport_authdata in \
                     chain_state.last_node_transport_state_authdata.clients_last_transport_authdata:
-                    if client_last_transport_authdata.address == to_canonical_address(light_client_transport._address):
+                    if client_last_transport_authdata.address == to_canonical_address(light_client_transport.address):
                         selected_prev_auth_data = client_last_transport_authdata.auth_data
 
             light_client_transport.start(
@@ -624,7 +624,7 @@ class RaidenService(Runnable):
 
     def _start_health_check_for_light_client_neighbour(self, chain_state: ChainState):
         for light_client in self.transport.light_client_transports:
-            for neighbour in views.all_neighbour_nodes(chain_state, light_client._address):
+            for neighbour in views.all_neighbour_nodes(chain_state, light_client.address):
                 self._start_health_check_for_neighbour(neighbour)
 
     def _start_health_check_for_hub_nighbours(self, chain_state: ChainState):
@@ -766,7 +766,7 @@ class RaidenService(Runnable):
             if creator_address is not None:
                 if self.transport.light_client_transports is not None:
                     for light_client_transport in self.transport.light_client_transports:
-                        if to_checksum_address(creator_address) == light_client_transport.get_address():
+                        if to_checksum_address(creator_address) == light_client_transport.address:
                             light_client_transport.start_health_check(node_address)
             else:
                 self.transport.hub_transport.start_health_check(node_address)
@@ -979,7 +979,7 @@ class RaidenService(Runnable):
     def get_light_client_transport(self, address):
         light_client_transport_result = None
         for light_client_transport in self.transport.light_client_transports:
-            if address == light_client_transport._address:
+            if address == light_client_transport.address:
                 light_client_transport_result = light_client_transport
 
         return light_client_transport_result
@@ -1020,7 +1020,7 @@ class RaidenService(Runnable):
                 if isinstance(event, SendLockedTransferLight):
                     transfer = event.signed_locked_transfer
                     for light_client_transport in light_client_transports:
-                        if transfer.initiator == to_canonical_address(light_client_transport._address):
+                        if transfer.initiator == to_canonical_address(light_client_transport.address):
                             light_client_transport.whitelist(address=transfer.target)
 
     def sign(self, message: Message):

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -297,6 +297,7 @@ def create_apps(
         database_path = database_from_privatekey(base_dir=database_basedir, app_number=idx)
 
         config = {
+            "address": address,
             "chain_id": chain_id,
             "environment_type": environment_type,
             "unrecoverable_error_should_crash": unrecoverable_error_should_crash,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -112,16 +112,16 @@ def _setup_matrix(config):
                     continue
 
             light_client_transport = get_matrix_light_client_instance(
+                light_client['address'],
                 config["transport"]["matrix"],
                 light_client['password'],
                 light_client['display_name'],
                 light_client['seed_retry'],
-                light_client['address'],
                 current_server_name)
 
             light_client_transports.append(light_client_transport)
 
-        hub_transport = MatrixTransport(config["transport"]["matrix"])
+        hub_transport = MatrixTransport(config["address"], config["transport"]["matrix"])
 
         node_transport = NodeTransport(hub_transport, light_client_transports)
 
@@ -133,19 +133,19 @@ def _setup_matrix(config):
 
 
 def get_matrix_light_client_instance(
+    address,
     config,
     password,
     display_name,
     seed_retry,
-    address,
     current_server_name: str = None
 ):
     light_client_transport = MatrixLightClientTransport(
+        address,
         config,
         password,
         display_name,
         seed_retry,
-        address,
         current_server_name
     )
     return light_client_transport
@@ -282,7 +282,6 @@ def run_app(
         config["transport"]["udp"]["external_port"] = mapped_socket.external_port
     config["transport_type"] = transport
     config["transport"]["matrix"]["server"] = matrix_server
-    config["transport"]["matrix"]["address"] = address  # temp, all transport layers should eventually use line 268
     config["transport"]["udp"]["nat_keepalive_retries"] = DEFAULT_NAT_KEEPALIVE_RETRIES
     timeout = max_unresponsive_time / DEFAULT_NAT_KEEPALIVE_RETRIES
     config["transport"]["udp"]["nat_keepalive_timeout"] = timeout

--- a/transport/layer.py
+++ b/transport/layer.py
@@ -13,6 +13,7 @@ class TransportLayer(ABC):
     def __init__(self, address: Address):
         self._address = address  # source for messages transmitted over this layer
 
+    @property
     def address(self):
         return self._address
 


### PR DESCRIPTION
This PR normalizes the use of the `address` field in the `MatrixTransport` and `MatrixLightClientTransport` classes, in terms of complying with the `TransportLayer` abstraction and removing redundancy for this field.

More specifically:
- `address` is now a field for the `MatrixTransport` constructor (and therefore of the `MatrixLightClientTransport` constructor as well) instead of being hidden inside the `config` dict.
- `TransportLayer.address` method is now decorated with `@property`.
- all matrix transport layer references to `._address` and `get_address` were replaced with `TransportLayer.address` calls.
- `get_address` method is removed, since it is redundant.
- `config["transport"]["matrix"]["address"]` is also removed, since it is no longer used.

Closes [RLP-766](https://jirainfuy.atlassian.net/browse/RLP-766).