### PR TITLE
Feature/rlp 748/settlement light

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -51,7 +51,7 @@ from raiden.lightclient.models.light_client_payment import LightClientPayment, L
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
 
 from raiden.messages import RequestMonitoring, LockedTransfer, RevealSecret, Unlock, Delivered, SecretRequest, \
-    Processed, LockExpired
+    Processed, LockExpired, SettlementRequest
 from raiden.settings import DEFAULT_RETRY_TIMEOUT, DEVELOPMENT_CONTRACT_VERSION
 
 from raiden.transfer import architecture, views
@@ -455,6 +455,11 @@ class RaidenAPI:
         )
         assert channel_state, f"channel {channel_state} is gone"
         return channel_state.identifier
+
+    def send_settlement_light(self, message: Dict, signed_tx: typing.SignedTransaction):
+        request = SettlementRequest.from_dict(message)
+        token_network = self.raiden.chain.token_network(request.channel_network_identifier)
+        token_network.send_settlement_light(signed_tx)
 
     def channel_open(
         self,

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -403,6 +403,16 @@ class PaymentLightPutSchema(BaseSchema):
         decoding_class = dict
 
 
+class SettlementLightSchema(BaseSchema):
+    message = fields.Dict(required=True)
+    signed_tx = fields.String(required=True)
+
+    class Meta:
+        strict = True
+        # decoding to a dict is required by the @use_kwargs decorator from webargs:
+        decoding_class = dict
+
+
 class WatchtowerPutResource(BaseSchema):
     sender = AddressField(required=True)
     light_client_payment_id = fields.Integer(required=True)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -27,7 +27,7 @@ from raiden.api.v1.encoding import (
     LightClientMatrixCredentialsBuildSchema,
     PaymentLightPutSchema,
     CreatePaymentLightPostSchema,
-    WatchtowerPutResource, LightClientMessageGetSchema)
+    WatchtowerPutResource, LightClientMessageGetSchema, SettlementLightSchema)
 from raiden.messages import  Unlock
 
 from raiden.utils import typing
@@ -301,6 +301,19 @@ class CreatePaymentLightResource(BaseResource):
             amount=amount,
             secrethash=secrethash
         )
+
+
+class SettlementLightResource(BaseResource):
+    put_schema = SettlementLightSchema
+
+    @use_kwargs(put_schema, locations=("json",))
+    def put(self,
+            message: Dict,
+            signed_tx: str):
+        """
+        put a settlement signed tx to be send by the hub
+        """
+        return self.rest_api.receive_light_client_signed_settlement(message, signed_tx)
 
 
 class LightClientMessageResource(BaseResource):

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -6,7 +6,7 @@ from eth_utils import (
     decode_hex,
     encode_hex,
     to_canonical_address,
-    to_normalized_address,
+    to_normalized_address, to_checksum_address,
 )
 
 from raiden.constants import UINT64_MAX, UINT256_MAX, EMPTY_PAYMENT_HASH_INVOICE
@@ -1831,6 +1831,89 @@ class RequestMonitoring(SignedMessage):
             and recover(reward_proof_data, self.reward_proof_signature) == requesting_address
         )
 
+
+class SettlementRequest(Message):
+    """ A Message to process by the light client when we have a incoming settlement event.
+        We use this as a payload to be signed by the lc and sent by the node.
+    """
+
+    def __init__(self,
+                 channel_network_identifier: TokenNetworkAddress,
+                 channel_identifier: ChannelID,
+                 participant1: Address,
+                 participant1_transferred_amount: TokenAmount,
+                 participant1_locked_amount: TokenAmount,
+                 participant1_locksroot: Locksroot,
+                 participant2: Address,
+                 participant2_transferred_amount: TokenAmount,
+                 participant2_locked_amount: TokenAmount,
+                 participant2_locksroot: Locksroot):
+        self.channel_network_identifier = channel_network_identifier
+        self.channel_identifier = channel_identifier
+        self.participant1 = participant1
+        self.participant1_transferred_amount = participant1_transferred_amount,
+        self.participant1_locked_amount = participant1_locked_amount,
+        self.participant1_locksroot = participant1_locksroot,
+        self.participant2 = participant2,
+        self.participant2_transferred_amount = participant2_transferred_amount,
+        self.participant2_locked_amount = participant2_locked_amount,
+        self.participant2_locksroot = participant2_locksroot
+
+    @classmethod
+    def unpack(cls, packed) -> "SettlementRequest":
+        return cls(
+            channel_network_identifier=packed.channel_network_identifier,
+            channel_identifier=packed.channel_identifier,
+            participant1=packed.participant1,
+            participant1_transferred_amount=packed.participant1_transferred_amount,
+            participant1_locked_amount=packed.participant1_locked_amount,
+            participant1_locksroot=packed.participant1_locksroot,
+            participant2=packed.participant2,
+            participant2_transferred_amount=packed.participant2_transferred_amount,
+            participant2_locked_amount=packed.participant2_locked_amount,
+            participant2_locksroot=packed.participant2_locksroot
+        )
+
+    def pack(self, packed) -> None:
+        self.channel_network_identifier = packed.channel_network_identifier
+        self.channel_identifier = packed.channel_identifier
+        self.participant1 = packed.participant1
+        self.participant1_transferred_amount = packed.participant1_transferred_amount,
+        self.participant1_locked_amount = packed.participant1_locked_amount,
+        self.participant1_locksroot = packed.participant1_locksroot,
+        self.participant2 = packed.participant2,
+        self.participant2_transferred_amount = packed.participant2_transferred_amount,
+        self.participant2_locked_amount = packed.participant2_locked_amount,
+        self.participant2_locksroot = packed.participant2_locksroot
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "channel_network_identifier": to_checksum_address(self.channel_network_identifier),
+            "channel_identifier": self.channel_identifier,
+            "participant1": to_checksum_address(self.participant1),
+            "participant1_transferred_amount": self.participant1_transferred_amount,
+            "participant1_locked_amount": self.participant1_locked_amount,
+            "participant1_locksroot": self.participant1_locksroot,
+            "participant2": to_checksum_address(self.participant2),
+            "participant2_transferred_amount": self.participant2_transferred_amount,
+            "participant2_locked_amount": self.participant2_locked_amount,
+            "participant2_locksroot": self.participant2_locksroot
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SettlementRequest":
+        return cls(
+            channel_network_identifier=to_canonical_address(data["channel_network_identifier"]),
+            channel_identifier=int(data["channel_identifier"]),
+            participant1=to_canonical_address(data["participant1"]),
+            participant1_transferred_amount=TokenAmount(data["participant1_transferred_amount"]),
+            participant1_locked_amount=TokenAmount(data["participant1_locked_amount"]),
+            participant1_locksroot=Locksroot(data["participant1_locksroot"]),
+            participant2=to_canonical_address(data["participant2"]),
+            participant2_transferred_amount=TokenAmount(data["participant2_transferred_amount"]),
+            participant2_locked_amount=TokenAmount(data["participant2_locked_amount"]),
+            participant2_locksroot=Locksroot(data["participant2_locksroot"]),
+        )
 
 CMDID_TO_CLASS: Dict[int, Type[Message]] = {
     messages.DELIVERED: Delivered,

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -5,6 +5,7 @@ from web3.utils.filters import Filter
 
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.network.proxies.token_network import ChannelDetails, TokenNetwork
+from raiden.transfer.events import ContractSendChannelSettle
 from raiden.utils.filters import decode_event, get_filter_args_for_specific_event_from_channel
 from raiden.utils.typing import (
     AdditionalHash,
@@ -283,6 +284,8 @@ class PaymentChannel:
 
     def settle(
         self,
+        raiden: "RaidenService",
+        channel_settle_event: ContractSendChannelSettle,
         transferred_amount: TokenAmount,
         locked_amount: TokenAmount,
         locksroot: Locksroot,
@@ -293,7 +296,8 @@ class PaymentChannel:
     ):
         """ Settles the channel. """
         self.token_network.settle(
-            channel_identifier=self.channel_identifier,
+            raiden=raiden,
+            channel_settle_event=channel_settle_event,
             transferred_amount=transferred_amount,
             locked_amount=locked_amount,
             locksroot=locksroot,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2285,7 +2285,6 @@ class TokenNetwork:
         else:
             log.info("Is light client, storing new state to handle message for settlement.", **log_details)
             # is LC, we create a new state to store a message for the LC
-            print("ARGS", kwargs)
             store_settlement_message = ActionStoreSettlementMessage(
                 lc_address=self_or_lc_address,
                 channel_network_identifier=channel_network_identifier,

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1620,7 +1620,6 @@ class ActionStoreSettlementMessage(StateChange):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ActionStoreSettlementMessage":
-        print("DATA", data)
         return cls(
             lc_address=to_canonical_address(data["lc_address"]),
             channel_network_identifier=to_canonical_address(data["channel_network_identifier"]),

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1537,3 +1537,100 @@ class ReceiveProcessed(AuthenticatedSenderStateChange):
             sender=to_canonical_address(data["sender"]),
             message_identifier=MessageID(int(data["message_identifier"])),
         )
+
+
+class ActionStoreSettlementMessage(StateChange):
+    """ A settlement required message has to be stored for the LC """
+
+    def __init__(self,
+                 lc_address: Address,
+                 channel_network_identifier: TokenNetworkAddress,
+                 channel_identifier: ChannelID,
+                 participant1: Address,
+                 participant1_transferred_amount: TokenAmount,
+                 participant1_locked_amount: TokenAmount,
+                 participant1_locksroot: Locksroot,
+                 participant2: Address,
+                 participant2_transferred_amount: TokenAmount,
+                 participant2_locked_amount: TokenAmount,
+                 participant2_locksroot: Locksroot) -> None:
+
+        if not isinstance(participant1, T_Address):
+            raise ValueError("participant1 must be an address instance")
+        if not isinstance(participant2, T_Address):
+            raise ValueError("participant2 must be an address instance")
+
+        self.lc_address = lc_address
+        self.channel_network_identifier = channel_network_identifier
+        self.channel_identifier = channel_identifier,
+        self.participant1 = participant1,
+        self.participant1_transferred_amount = participant1_transferred_amount,
+        self.participant1_locked_amount = participant1_locked_amount,
+        self.participant1_locksroot = participant1_locksroot,
+        self.participant2 = participant2,
+        self.participant2_transferred_amount = participant2_transferred_amount,
+        self.participant2_locked_amount = participant2_locked_amount,
+        self.participant2_locksroot = participant2_locksroot
+
+    def __repr__(self) -> str:
+        return "<ActionStoreSettlementMessage lc_address:{} channel_network_identifier:{}" \
+               " channel_identifier:{} participant1:{} " \
+               "participant1_transferred_amount:{} participant1_locked_amount:{} " \
+               "participant1_locksroot:{} participant2:{} participant2_transferred_amount:{} " \
+               "participant2_locked_amount:{} participant2_locksroot: {}>"\
+            .format(self.lc_address, self.channel_network_identifier, self.channel_identifier,
+                    pex(self.participant1[0]), self.participant1_transferred_amount,
+                    self.participant1_locked_amount, self.participant1_locksroot,
+                    pex(self.participant2[0]), self.participant2_transferred_amount,
+                    self.participant2_locked_amount, self.participant2_locksroot)
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ActionStoreSettlementMessage)
+            and self.lc_address == other.lc_address
+            and self.channel_network_identifier == other.channel_network_identifier
+            and self.channel_identifier == other.channel_identifier
+            and self.participant1 == other.participant1
+            and self.participant1_transferred_amount == other.participant1_transferred_amount
+            and self.participant1_locked_amount == other.participant1_locked_amount
+            and self.participant1_locksroot == other.participant1_locksroot
+            and self.participant2 == other.participant2
+            and self.participant2_transferred_amount == other.participant2_transferred_amount
+            and self.participant2_locked_amount == other.participant2_locked_amount
+            and self.participant2_locksroot == other.participant2_locksroot
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "lc_address": to_checksum_address(self.lc_address),
+            "channel_network_identifier": to_checksum_address(self.channel_network_identifier),
+            "channel_identifier": self.channel_identifier,
+            "participant1": to_checksum_address(self.participant1[0]),
+            "participant1_transferred_amount": self.participant1_transferred_amount,
+            "participant1_locked_amount": self.participant1_locked_amount,
+            "participant1_locksroot": serialize_bytes(self.participant1_locksroot[0]),
+            "participant2": to_checksum_address(self.participant2[0]),
+            "participant2_transferred_amount": self.participant2_transferred_amount,
+            "participant2_locked_amount": self.participant2_locked_amount,
+            "participant2_locksroot": serialize_bytes(self.participant2_locksroot)
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ActionStoreSettlementMessage":
+        print("DATA", data)
+        return cls(
+            lc_address=to_canonical_address(data["lc_address"]),
+            channel_network_identifier=to_canonical_address(data["channel_network_identifier"]),
+            channel_identifier=ChannelID(int(data["channel_identifier"])),
+            participant1=to_canonical_address(data["participant1"]),
+            participant1_transferred_amount=TokenAmount(int(data["participant1_transferred_amount"])),
+            participant1_locked_amount=TokenAmount(int(data["participant1_locked_amount"])),
+            participant1_locksroot=Locksroot(deserialize_bytes(data["participant1_locksroot"])),
+            participant2=to_canonical_address(data["participant2"]),
+            participant2_transferred_amount=TokenAmount(int(data["participant2_transferred_amount"])),
+            participant2_locked_amount=TokenAmount(int(data["participant2_locked_amount"])),
+            participant2_locksroot=Locksroot(deserialize_bytes(data["participant2_locksroot"])),
+        )


### PR DESCRIPTION
This PR introduces the ability to execute the settlement process from light clients.

Here we are:

* Adding new state change to store a message for the LC
* Adding new message for the LC as a payload to be signed
* Adding the handling of the new state to store the message
* Adding new endpoint to handle the settlement light with the signed message

Now a light client will be able to settle a channel after the channel is closed and ready for settle.

