### PR TITLE
RLP-767: remove send_for_light_client_with_retry

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -156,15 +156,6 @@ class _RetryQueue(Runnable):
             )
         self.notify()
 
-    def enqueue_global(self, message: Message):
-        """ Helper to enqueue a message in the global queue (e.g. Delivered) """
-        self.enqueue(
-            queue_identifier=QueueIdentifier(
-                recipient=self.receiver, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
-            ),
-            message=message,
-        )
-
     def notify(self):
         """ Notify main loop to check if anything needs to be sent """
         with self._lock:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -521,7 +521,7 @@ class MatrixTransport(TransportLayer, Runnable):
             raise ValueError("Invalid address {}".format(pex(receiver_address)))
 
         # These are not protocol messages, but transport specific messages
-        if isinstance(message, (Delivered, Ping, Pong)):
+        if isinstance(message, (Ping, Pong)):
             raise ValueError(
                 "Do not use send_async for {} messages".format(message.__class__.__name__)
             )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -47,7 +47,9 @@ from raiden.storage import serialize, sqlite, wal
 from raiden.tasks import AlarmTask
 from raiden.transfer import node, views
 from raiden.transfer.architecture import Event as RaidenEvent, StateChange
-from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendLockedTransferLight
+from raiden.transfer.identifiers import QueueIdentifier
+from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendLockedTransferLight, \
+    CHANNEL_IDENTIFIER_GLOBAL_QUEUE
 
 from raiden.transfer.mediated_transfer.state import (
     TransferDescriptionWithSecretState,
@@ -1330,7 +1332,10 @@ class RaidenService(Runnable):
                 message_type,
                 self.wal
             )
-            lc_transport.send_for_light_client_with_retry(receiver_address, delivered)
+            queue_identifier = QueueIdentifier(
+                recipient=receiver_address, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
+            )
+            lc_transport.send_async(queue_identifier, delivered)
 
     def initiate_send_processed_light(self, sender_address: Address, receiver_address: Address,
                                       processed: Processed, msg_order: int, payment_id: int,
@@ -1346,7 +1351,10 @@ class RaidenService(Runnable):
                 message_type,
                 self.wal
             )
-            lc_transport.send_for_light_client_with_retry(receiver_address, processed)
+            queue_identifier = QueueIdentifier(
+                recipient=receiver_address, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
+            )
+            lc_transport.send_async(queue_identifier, processed)
 
     def initiate_send_secret_reveal_light(
         self,


### PR DESCRIPTION
### problem
- under #110, transport variables are now of the `TransportLayer` abstract class type.
- the raiden service currently calls the `send_for_light_client_with_retry` method, which is not only _just_ implemented by `MatrixLightClientTransport`—and not `MatrixTransport`—but it is also **not** part of the `TransportLayer` abstraction.

### analysis
what is the difference between `send_for_light_client_with_retry` and `send_async`?

```python
# MatrixLightClientTransport
def send_for_light_client_with_retry(self, receiver: Address, message: Message):
    retrier = self._get_retrier(receiver)
    retrier.enqueue_global(message)

# MatrixTransport
def _get_retrier(self, receiver: Address) -> _RetryQueue:
    if receiver not in self._address_to_retrier:
        retrier = _RetryQueue(transport=self, receiver=receiver)
        self._address_to_retrier[receiver] = retrier
        retrier.start()
    return self._address_to_retrier[receiver]

# _RetryQueue
def enqueue_global(self, message: Message):
    self.enqueue(
        queue_identifier=QueueIdentifier(
            recipient=self.receiver, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
        ),
        message=message,
    )
```

---

```python
# MatrixTransport
def send_async(self, queue_identifier: QueueIdentifier, message: Message):
    receiver_address = queue_identifier.recipient

    if not is_binary_address(receiver_address):
        raise ValueError("Invalid address {}".format(pex(receiver_address)))

    if isinstance(message, (Delivered, Ping, Pong)):
        raise ValueError(
            "Do not use send_async for {} messages".format(message.__class__.__name__)
        )

    self.log.info(
        "Send async",
        receiver_address=pex(receiver_address),
        message=message,
        queue_identifier=queue_identifier,
    )

    self._send_with_retry(queue_identifier, message)

# MatrixTransport
def _send_with_retry(self, queue_identifier: QueueIdentifier, message: Message):
    retrier = self._get_retrier(queue_identifier.recipient)
    retrier.enqueue(queue_identifier=queue_identifier, message=message)
```

both:
- fetch a retrier for a message recipient
- use the retrier to put the given message on a queue

but:
- `send_async` receives the queue identifier directly, while `send_for_light_client_with_retry` ends-up building its own queue identifier with `CHANNEL_IDENTIFIER_GLOBAL_QUEUE` as its channel identifier.
- `send_async` does not allow `Delivered` messages. on the other hand, `send_for_light_client_with_retry` allows any message, although currently it is only called with `Delivered` and `Processed`.

### solution
this pr:
- removes the `enqueue_global` method.
- replaces `send_for_light_client_with_retry` calls with—hopefully equivalent—`send_async` calls, but previously building the queue identifier using the same logic as `enqueue_global` used to have.
- removes the `send_for_light_client_with_retry` method.
- removes the code which prevents `Delivered` messages from being sent through `send_async`. this was wrong, as we were ultimately calling `enqueue` on these types of messages through `send_for_light_client_with_retry` anyways.

closes [RLP-767](https://jirainfuy.atlassian.net/browse/RLP-767).