### PR TITLE
Feature/rlp 748/settlement light

### DIFF
--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -1,3 +1,6 @@
+from raiden.utils.typing import TokenAmount, Locksroot, BlockHash
+
+
 class FlatList(list):
     """
     This class inherits from list and has the same interface as a list-type.
@@ -56,3 +59,22 @@ class DashboardGeneralItem:
     quantity = 0
     event_type_code = 0
     event_type_class_name = ""
+
+
+class SettlementParameters:
+    """" Object to store settlement parameters for internal use """
+    def __init__(self,
+                 transferred_amount: TokenAmount,
+                 locked_amount: TokenAmount,
+                 locksroot: Locksroot,
+                 partner_transferred_amount: TokenAmount,
+                 partner_locked_amount: TokenAmount,
+                 partner_locksroot: Locksroot,
+                 block_identifier: BlockHash):
+        self.transferred_amount = transferred_amount,
+        self.locked_amount = locked_amount,
+        self.locksroot = locksroot,
+        self.partner_transferred_amount = partner_transferred_amount,
+        self.partner_locked_amount = partner_locked_amount,
+        self.partner_locksroot = partner_locksroot,
+        self.block_identifier = block_identifier

--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -71,10 +71,10 @@ class SettlementParameters:
                  partner_locked_amount: TokenAmount,
                  partner_locksroot: Locksroot,
                  block_identifier: BlockHash):
-        self.transferred_amount = transferred_amount,
-        self.locked_amount = locked_amount,
-        self.locksroot = locksroot,
-        self.partner_transferred_amount = partner_transferred_amount,
-        self.partner_locked_amount = partner_locked_amount,
-        self.partner_locksroot = partner_locksroot,
+        self.transferred_amount = transferred_amount
+        self.locked_amount = locked_amount
+        self.locksroot = locksroot
+        self.partner_transferred_amount = partner_transferred_amount
+        self.partner_locked_amount = partner_locked_amount
+        self.partner_locksroot = partner_locksroot
         self.block_identifier = block_identifier

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -590,12 +590,14 @@ class RaidenAPI:
         Race condition, this can fail if channel was settled externally.
         """
 
+        chain_state = views.state_from_raiden(self.raiden)
+
         channels_to_settle = ChannelValidator.validate_and_get_channels_to_settle(
             token_address=token_address,
             creator_address=creator_address,
             partner_address=partner_address,
             registry_address=registry_address,
-            raiden=self.raiden)
+            chain_state=chain_state)
 
         # get the channel to settle
         channel_iterator = filter(lambda channel:

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -70,7 +70,7 @@ from raiden.transfer.state import (
     TransferTask,
     ChainState)
 
-from raiden.transfer.state_change import ActionChannelClose, ActionChannelSettle
+from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils import pex, typing
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 from raiden.utils.typing import (

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -618,7 +618,7 @@ class RaidenAPI:
         )
 
         channel_proxy.settle_channel_light(
-            block_identifier=views.state_from_raiden(self.raiden).block_hash,
+            block_identifier=chain_state.block_hash,
             signed_settle_tx=signed_settle_tx
         )
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -589,7 +589,7 @@ class RaidenAPI:
 
         channels_to_settle = ChannelValidator.validate_and_get_channels_to_settle(
             token_address=token_address,
-            partner_addresses=[partner_address],
+            partner_address=partner_address,
             registry_address=registry_address,
             raiden=self.raiden)
 
@@ -625,6 +625,8 @@ class RaidenAPI:
             retry_timeout=DEFAULT_RETRY_TIMEOUT,
             partner_addresses=[partner_address]
         )
+
+        return channel_state
 
     def set_total_channel_deposit_light(
         self,
@@ -812,7 +814,7 @@ class RaidenAPI:
             `token_address`.
             Race condition, this can fail if channel was settled externally.
         """
-        self.settle_light(
+        return self.settle_light(
             registry_address=registry_address,
             token_address=token_address,
             creator_address=creator_address,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -608,7 +608,7 @@ class RaidenAPI:
 
         channel_list = list(channel_iterator)
 
-        if len(channel_list) <= 0:
+        if not channel_list:
             raise RaidenRecoverableError("Failed trying to settle a channel that's not in waiting_for_settle state")
 
         channel_state = channel_list[0]

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -587,7 +587,7 @@ class RaidenAPI:
         Race condition, this can fail if channel was settled externally.
         """
 
-        channels_to_settle = ChannelValidator.can_settle_channel(
+        channels_to_settle = ChannelValidator.validate_and_get_channels_to_settle(
             token_address=token_address,
             partner_addresses=[partner_address],
             registry_address=registry_address,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -605,6 +605,9 @@ class RaidenAPI:
             partner_address=partner_address,
         )
 
+        if channel_state.identifier not in channel_ids:
+            raise RaidenRecoverableError("Failed trying to settle a channel that's not in waiting_for_settle state")
+
         channel_proxy = self.raiden.chain.payment_channel(
             canonical_identifier=channel_state.canonical_identifier
         )

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -121,8 +121,7 @@ from raiden.transfer.events import (
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
 )
-from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, NettingChannelState, \
-    CHANNEL_STATE_SETTLING
+from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, NettingChannelState
 from raiden.utils import (
     create_default_identifier,
     optional_address_to_string,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1907,7 +1907,13 @@ class RestAPI:
         elif state == CHANNEL_STATE_CLOSED:
             result = self._close_light(registry_address, channel_state, signed_close_tx)
         elif state == CHANNEL_STATE_SETTLING:
-            result = self._settle_light(registry_address, channel_state, signed_settle_tx)
+            if signed_settle_tx:
+                result = self._settle_light(registry_address, channel_state, signed_settle_tx)
+            else:
+                result = api_error(
+                    errors="Signed settle transaction is required for state {}".format(state),
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
         else:  # should never happen, channel_state is validated in the schema
             result = api_error(
                 errors="Provided invalid channel state {}".format(state),

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -19,7 +19,8 @@ from raiden.api.objects import Address, AddressList, PartnersPerToken, PartnersP
 from raiden.constants import SECRET_LENGTH, SECRETHASH_LENGTH
 from raiden.settings import DEFAULT_INITIAL_CHANNEL_TARGET, DEFAULT_JOINABLE_FUNDS_TARGET
 from raiden.transfer import channel
-from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED
+from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED, \
+    CHANNEL_STATE_SETTLING
 from raiden.utils import data_decoder, data_encoder
 
 
@@ -471,7 +472,7 @@ class ChannelLightPatchSchema(BaseSchema):
         default=None,
         missing=None,
         validate=validate.OneOf(
-            [CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED]
+            [CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED, CHANNEL_STATE_SETTLING]
         ),
     )
     signed_approval_tx = fields.String(required=True)

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -478,7 +478,11 @@ class ChannelLightPatchSchema(BaseSchema):
     signed_approval_tx = fields.String(required=True)
     signed_deposit_tx = fields.String(required=True)
     signed_close_tx = fields.String(required=True)
-    signed_settle_tx = fields.String(required=False)
+    signed_settle_tx = fields.String(
+        default=None,
+        missing=None,
+        required=False
+    )
 
     class Meta:
         strict = True

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -19,8 +19,7 @@ from raiden.api.objects import Address, AddressList, PartnersPerToken, PartnersP
 from raiden.constants import SECRET_LENGTH, SECRETHASH_LENGTH
 from raiden.settings import DEFAULT_INITIAL_CHANNEL_TARGET, DEFAULT_JOINABLE_FUNDS_TARGET
 from raiden.transfer import channel
-from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED, \
-    CHANNEL_STATE_SETTLING
+from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED
 from raiden.utils import data_decoder, data_encoder
 
 
@@ -474,17 +473,12 @@ class ChannelLightPatchSchema(BaseSchema):
         default=None,
         missing=None,
         validate=validate.OneOf(
-            [CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED, CHANNEL_STATE_SETTLING]
+            [CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED, CHANNEL_STATE_SETTLED]
         ),
     )
     signed_approval_tx = fields.String(required=True)
     signed_deposit_tx = fields.String(required=True)
     signed_close_tx = fields.String(required=True)
-    signed_settle_tx = fields.String(
-        default=None,
-        missing=None,
-        required=False
-    )
 
     class Meta:
         strict = True
@@ -494,6 +488,7 @@ class ChannelLightPatchSchema(BaseSchema):
 
 class SettlementLightSchema(BaseSchema):
     signed_settle_tx = fields.String(required=True)
+    channel_identifier = fields.Integer(required=True)
 
     class Meta:
         strict = True

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -478,6 +478,7 @@ class ChannelLightPatchSchema(BaseSchema):
     signed_approval_tx = fields.String(required=True)
     signed_deposit_tx = fields.String(required=True)
     signed_close_tx = fields.String(required=True)
+    signed_settle_tx = fields.String(required=False)
 
     class Meta:
         strict = True

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -490,6 +490,15 @@ class ChannelLightPatchSchema(BaseSchema):
         decoding_class = dict
 
 
+class SettlementLightSchema(BaseSchema):
+    signed_settle_tx = fields.String(required=True)
+
+    class Meta:
+        strict = True
+        # decoding to a dict is required by the @use_kwargs decorator from webargs:
+        decoding_class = dict
+
+
 class PaymentSchema(BaseSchema):
     initiator_address = AddressField(missing=None)
     target_address = AddressField(missing=None)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -151,6 +151,16 @@ class LightChannelsResourceByTokenAndPartnerAddress(BaseResource):
         )
 
 
+class SettlementLightResourceByTokenAndPartnerAddress(BaseResource):
+    schema = ChannelLightPatchSchema
+
+    @use_kwargs(schema, locations=("json",))
+    def post(self, **kwargs):
+        return self.rest_api.settlement_light(
+            registry_address=self.rest_api.raiden_api.raiden.default_registry.address, **kwargs
+        )
+
+
 class TokensResource(BaseResource):
     def get(self):
         """

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -27,7 +27,7 @@ from raiden.api.v1.encoding import (
     LightClientMatrixCredentialsBuildSchema,
     PaymentLightPutSchema,
     CreatePaymentLightPostSchema,
-    WatchtowerPutResource, LightClientMessageGetSchema)
+    WatchtowerPutResource, LightClientMessageGetSchema, SettlementLightSchema)
 from raiden.messages import  Unlock
 
 from raiden.utils import typing
@@ -152,7 +152,7 @@ class LightChannelsResourceByTokenAndPartnerAddress(BaseResource):
 
 
 class SettlementLightResourceByTokenAndPartnerAddress(BaseResource):
-    schema = ChannelLightPatchSchema
+    schema = SettlementLightSchema
 
     @use_kwargs(schema, locations=("json",))
     def post(self, **kwargs):

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -122,6 +122,7 @@ class ChannelValidator:
 
     @staticmethod
     def validate_and_get_channels_to_settle(token_address,
+                                            creator_address,
                                             partner_address,
                                             registry_address,
                                             raiden):
@@ -142,7 +143,8 @@ class ChannelValidator:
         channels = views.get_channelstate_settling(
             chain_state=chain_state,
             payment_network_id=registry_address,
-            token_address=token_address
+            token_address=token_address,
+            creator_address=creator_address
         )
 
         channels_to_settle: List[NettingChannelState] = []

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -9,7 +9,7 @@ from raiden.exceptions import AddressWithoutCode, InvalidSettleTimeout, InvalidA
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies import Token, TokenNetworkRegistry, TokenNetwork
 from raiden.transfer import views
-from raiden.transfer.state import NettingChannelState
+from raiden.transfer.state import NettingChannelState, ChainState
 from raiden.utils import typing, pex
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 from raiden.utils.typing import PaymentNetworkID, TokenAddress, Address, BlockTimeout, List
@@ -121,11 +121,11 @@ class ChannelValidator:
         return channels_to_close
 
     @staticmethod
-    def validate_and_get_channels_to_settle(token_address,
-                                            creator_address,
-                                            partner_address,
-                                            registry_address,
-                                            raiden):
+    def validate_and_get_channels_to_settle(token_address: TokenAddress,
+                                            creator_address: Address,
+                                            partner_address: Address,
+                                            registry_address: Address,
+                                            chain_state: ChainState):
 
         if not is_binary_address(token_address):
             raise InvalidAddress("Expected binary address format for token in channel settle")
@@ -134,12 +134,11 @@ class ChannelValidator:
             raise InvalidAddress("Expected binary address format for partner address in channel settle")
 
         valid_tokens = views.get_token_identifiers(
-            chain_state=views.state_from_raiden(raiden), payment_network_id=registry_address
+            chain_state=chain_state, payment_network_id=registry_address
         )
         if token_address not in valid_tokens:
             raise UnknownTokenAddress("Token address is not known in channel settle.")
 
-        chain_state = views.state_from_raiden(raiden)
         channels = views.get_channelstate_settling(
             chain_state=chain_state,
             payment_network_id=registry_address,

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -120,10 +120,10 @@ class ChannelValidator:
         return channels_to_close
 
     @staticmethod
-    def can_settle_channel(token_address,
-                           partner_addresses,
-                           registry_address,
-                           raiden):
+    def validate_and_get_channels_to_settle(token_address,
+                                            partner_addresses,
+                                            registry_address,
+                                            raiden):
 
         if not is_binary_address(token_address):
             raise InvalidAddress("Expected binary address format for token in channel settle")

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -118,3 +118,31 @@ class ChannelValidator:
         )
 
         return channels_to_close
+
+    @staticmethod
+    def can_settle_channel(token_address,
+                           partner_addresses,
+                           registry_address,
+                           raiden):
+
+        if not is_binary_address(token_address):
+            raise InvalidAddress("Expected binary address format for token in channel settle")
+
+        if not all(map(is_binary_address, partner_addresses)):
+            raise InvalidAddress("Expected binary address format for partner in channel settle")
+
+        valid_tokens = views.get_token_identifiers(
+            chain_state=views.state_from_raiden(raiden), payment_network_id=registry_address
+        )
+        if token_address not in valid_tokens:
+            raise UnknownTokenAddress("Token address is not known in channel settle.")
+
+        chain_state = views.state_from_raiden(raiden)
+        channels_to_settle = views.filter_channels_to_settle_by_partner_address(
+            chain_state=chain_state,
+            payment_network_id=registry_address,
+            token_address=token_address,
+            partner_addresses=partner_addresses,
+        )
+
+        return channels_to_settle

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -152,4 +152,4 @@ class ChannelValidator:
             if channel.partner_state.address == partner_address:
                 channels_to_settle.append(channel)
 
-        return channels
+        return channels_to_settle

--- a/raiden/api/validations/channel_validator.py
+++ b/raiden/api/validations/channel_validator.py
@@ -125,7 +125,7 @@ class ChannelValidator:
                                             creator_address: Address,
                                             partner_address: Address,
                                             registry_address: Address,
-                                            chain_state: ChainState):
+                                            chain_state: ChainState) -> List[NettingChannelState]:
 
         if not is_binary_address(token_address):
             raise InvalidAddress("Expected binary address format for token in channel settle")

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -107,10 +107,10 @@ class LightClientMessageHandler:
                                   unsigned_message: Message,
                                   wal: WriteAheadLog):
 
-        return message_type and light_client_address and unsigned_message \
-                            and wal.storage.is_message_already_stored(light_client_address,
-                                                                      message_type.value,
-                                                                      unsigned_message) is not None
+        return message_type and light_client_address and unsigned_message and wal.storage\
+            .is_message_already_stored(light_client_address,
+                                       message_type.value,
+                                       unsigned_message)
 
     @classmethod
     def is_light_client_protocol_message_already_stored_message_id(cls, message_id: int, payment_id: int, order: int,

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -105,24 +105,10 @@ class LightClientMessageHandler:
                                   unsigned_message: Message,
                                   wal: WriteAheadLog):
 
-        if message_type and light_client_address and unsigned_message:
-            existing_message = wal.storage.is_message_already_stored(light_client_address,
-                                                                     message_type.value,
-                                                                     unsigned_message)
-
-            if existing_message:
-                return LightClientProtocolMessage(existing_message[5] is not None,
-                                                  existing_message[3],
-                                                  existing_message[2],
-                                                  existing_message[1],
-                                                  existing_message[6],
-                                                  existing_message[4],
-                                                  existing_message[5],
-                                                  existing_message[0],
-                                                  existing_message[7])
-            return existing_message
-        else:
-            return False
+        return message_type and light_client_address and unsigned_message \
+                            and wal.storage.is_message_already_stored(light_client_address,
+                                                                      message_type.value,
+                                                                      unsigned_message) is not None
 
     @classmethod
     def is_light_client_protocol_message_already_stored_message_id(cls, message_id: int, payment_id: int, order: int,

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -43,9 +43,10 @@ class LightClientMessageHandler:
     log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
     @classmethod
-    def store_light_client_protocol_message(cls, identifier: int, message: Message, signed: bool, payment_id: int,
+    def store_light_client_protocol_message(cls, identifier: int, message: Message, signed: bool,
                                             light_client_address: AddressHex, order: int,
-                                            message_type: LightClientProtocolMessageType, wal: WriteAheadLog):
+                                            message_type: LightClientProtocolMessageType, wal: WriteAheadLog,
+                                            payment_id: int = None):
         return wal.storage.write_light_client_protocol_message(
             message,
             build_light_client_protocol_message(identifier, message, signed,
@@ -194,11 +195,11 @@ class LightClientMessageHandler:
                     message_identifier,
                     message,
                     True,
-                    protocol_message.light_client_payment_id,
                     protocol_message.light_client_address,
                     order,
                     message_type,
-                    wal
+                    wal,
+                    protocol_message.light_client_payment_id
                 )
             else:
                 cls.log.info("Message for lc already received, ignoring db storage")
@@ -255,9 +256,9 @@ class LightClientMessageHandler:
                 message_identifier, protocol_message.light_client_payment_id, order, wal)
             if not exists:
                 LightClientMessageHandler.store_light_client_protocol_message(
-                    message_identifier, message, True, protocol_message.light_client_payment_id,
+                    message_identifier, message, True,
                     protocol_message.light_client_address, order,
-                    message_type, wal)
+                    message_type, wal, protocol_message.light_client_payment_id)
             else:
                 cls.log.info("Message for lc already received, ignoring db storage")
 

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -99,6 +99,32 @@ class LightClientMessageHandler:
         return existing_message
 
     @classmethod
+    def is_message_already_stored(cls,
+                                  light_client_address: AddressHex,
+                                  message_type: LightClientProtocolMessageType,
+                                  unsigned_message: Message,
+                                  wal: WriteAheadLog):
+
+        if message_type and light_client_address and unsigned_message:
+            existing_message = wal.storage.is_message_already_stored(light_client_address,
+                                                                     message_type.value,
+                                                                     unsigned_message)
+
+            if existing_message:
+                return LightClientProtocolMessage(existing_message[5] is not None,
+                                                  existing_message[3],
+                                                  existing_message[2],
+                                                  existing_message[1],
+                                                  existing_message[6],
+                                                  existing_message[4],
+                                                  existing_message[5],
+                                                  existing_message[0],
+                                                  existing_message[7])
+            return existing_message
+        else:
+            return False
+
+    @classmethod
     def is_light_client_protocol_message_already_stored_message_id(cls, message_id: int, payment_id: int, order: int,
                                                                    wal: WriteAheadLog):
         return wal.storage.is_light_client_protocol_message_already_stored_with_message_id(message_id, payment_id,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1878,6 +1878,7 @@ class SettlementRequiredLightMessage(Message):
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "type": self.__class__.__name__,
             "channel_identifier": self.channel_identifier,
             "channel_network_identifier": to_normalized_address(self.channel_network_identifier),
             "participant1": to_normalized_address(self.participant1),
@@ -1892,6 +1893,8 @@ class SettlementRequiredLightMessage(Message):
 
     @classmethod
     def from_dict(cls, data) -> "SettlementRequiredLightMessage":
+        error_message = f'Cannot decode data. Provided type is {data["type"]}, expected {cls.__name__}'
+        assert data["type"] == cls.__name__, error_message
         return cls(channel_identifier=ChannelID(data["channel_identifier"]),
                    channel_network_identifier=TokenNetworkAddress(decode_hex(data["channel_network_identifier"])),
                    participant1=Address(decode_hex(data["participant1"])),

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1832,6 +1832,78 @@ class RequestMonitoring(SignedMessage):
         )
 
 
+class SettlementRequiredLightMessage(Message):
+    """ Represents the settlement required message for the LC when we need the LC to sign and send a settlement """
+    def __init__(self, channel_identifier: ChannelID, channel_network_identifier: TokenNetworkAddress,
+                 participant1: Address, participant1_transferred_amount: TokenAmount,
+                 participant1_locked_amount: TokenAmount, participant1_locksroot: Locksroot, participant2: Address,
+                 participant2_transferred_amount: TokenAmount, participant2_locked_amount: TokenAmount,
+                 participant2_locksroot: Locksroot, **kwargs):
+        super().__init__(**kwargs)
+        self.channel_identifier = channel_identifier
+        self.channel_network_identifier = channel_network_identifier
+        self.participant1 = participant1
+        self.participant1_transferred_amount = participant1_transferred_amount
+        self.participant1_locked_amount = participant1_locked_amount
+        self.participant1_locksroot = participant1_locksroot
+        self.participant2 = participant2
+        self.participant2_transferred_amount = participant2_transferred_amount
+        self.participant2_locked_amount = participant2_locked_amount
+        self.participant2_locksroot = participant2_locksroot
+
+    @classmethod
+    def unpack(cls, packed) -> "SettlementRequiredLightMessage":
+        return cls(channel_identifier=packed.channel_identifier,
+                   channel_network_identifier=packed.channel_network_identifier,
+                   participant1=packed.participant1,
+                   participant1_transferred_amount=packed.participant1_transferred_amount,
+                   participant1_locked_amount=packed.participant1_locked_amount,
+                   participant1_locksroot=packed.participant1_locksroot,
+                   participant2=packed.participant2,
+                   participant2_transferred_amount=packed.participant2_transferred_amount,
+                   participant2_locked_amount=packed.participant2_locked_amount,
+                   participant2_locksroot=packed.participant2_locksroot)
+
+    def pack(self, packed) -> None:
+        packed.channel_identifier = self.channel_identifier
+        packed.channel_network_identifier = self.channel_network_identifier
+        packed.participant1 = self.participant1
+        packed.participant1_transferred_amount = self.participant1_transferred_amount
+        packed.participant1_locked_amount = self.participant1_locked_amount
+        packed.participant1_locksroot = self.participant1_locksroot
+        packed.participant2 = self.participant2
+        packed.participant2_transferred_amount = self.participant2_transferred_amount
+        packed.participant2_locked_amount = self.participant2_locked_amount
+        packed.participant2_locksroot = self.participant2_locksroot
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "channel_identifier": self.channel_identifier,
+            "channel_network_identifier": to_normalized_address(self.channel_network_identifier),
+            "participant1": to_normalized_address(self.participant1),
+            "participant1_transferred_amount": self.participant1_transferred_amount,
+            "participant1_locked_amount": self.participant1_locked_amount,
+            "participant1_locksroot": encode_hex(self.participant1_locksroot),
+            "participant2": to_normalized_address(self.participant2),
+            "participant2_transferred_amount": self.participant2_transferred_amount,
+            "participant2_locked_amount": self.participant2_locked_amount,
+            "participant2_locksroot": encode_hex(self.participant2_locksroot)
+        }
+
+    @classmethod
+    def from_dict(cls, data) -> "SettlementRequiredLightMessage":
+        return cls(channel_identifier=ChannelID(data["channel_identifier"]),
+                   channel_network_identifier=TokenNetworkAddress(decode_hex(data["channel_network_identifier"])),
+                   participant1=Address(decode_hex(data["participant1"])),
+                   participant1_transferred_amount=TokenAmount(int(data["participant1_transferred_amount"])),
+                   participant1_locked_amount=TokenAmount(int(data["participant1_locked_amount"])),
+                   participant1_locksroot=Locksroot(decode_hex(data["participant1_locksroot"])),
+                   participant2=Address(decode_hex(data["participant2"])),
+                   participant2_transferred_amount=TokenAmount(int(data["participant2_transferred_amount"])),
+                   participant2_locked_amount=TokenAmount(int(data["participant2_locked_amount"])),
+                   participant2_locksroot=Locksroot(decode_hex(data["participant2_locksroot"])))
+
+
 CMDID_TO_CLASS: Dict[int, Type[Message]] = {
     messages.DELIVERED: Delivered,
     messages.LOCKEDTRANSFER: LockedTransfer,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1906,6 +1906,21 @@ class SettlementRequiredLightMessage(Message):
                    participant2_locked_amount=TokenAmount(int(data["participant2_locked_amount"])),
                    participant2_locksroot=Locksroot(decode_hex(data["participant2_locksroot"])))
 
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, SettlementRequiredLightMessage)
+            and self.channel_identifier == other.channel_identifier
+            and self.channel_network_identifier == other.channel_network_identifier
+            and self.participant1 == other.participant1
+            and self.participant1_transferred_amount == other.participant1_transferred_amount
+            and self.participant1_locked_amount == other.participant1_locked_amount
+            and self.participant1_locksroot == other.participant1_locksroot
+            and self.participant2 == other.participant2
+            and self.participant2_transferred_amount == other.participant2_transferred_amount
+            and self.participant2_locked_amount == other.participant2_locked_amount
+            and self.participant2_locksroot == other.participant2_locksroot
+        )
+
 
 CMDID_TO_CLASS: Dict[int, Type[Message]] = {
     messages.DELIVERED: Delivered,

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -181,6 +181,17 @@ class PaymentChannel:
             signed_deposit_tx=signed_deposit_tx
         )
 
+    def settle_channel_light(self,
+                             block_identifier: BlockSpecification,
+                             signed_settle_tx: SignedTransaction):
+        self.token_network.settle_light(
+            given_block_identifier=block_identifier,
+            channel_identifier=self.channel_identifier,
+            creator=self.participant1,
+            partner=self.participant2,
+            signed_settle_tx=signed_settle_tx
+        )
+
     def close(
         self,
         nonce: Nonce,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2213,6 +2213,8 @@ class TokenNetwork:
             # gas will stop us from sending a transaction that will fail
             pass
 
+        transaction_error = None
+
         with self.channel_operations_lock[partner]:
             error_prefix = "Call to settle will fail"
             gas_limit = self.proxy.estimate_gas(
@@ -2293,7 +2295,7 @@ class TokenNetwork:
         """
             This function throws an exception with details about the error
         """
-        if transaction_error["blockNumber"]:
+        if transaction_error and transaction_error["blockNumber"]:
             block = transaction_error["blockNumber"]
         else:
             block = checking_block
@@ -2301,7 +2303,7 @@ class TokenNetwork:
         self.proxy.jsonrpc_client.check_for_insufficient_eth(
             transaction_name="settleChannel",
             address=self.node_address,
-            transaction_executed=transaction_error["blockNumber"] is not None,
+            transaction_executed=transaction_error and transaction_error["blockNumber"] is not None,
             required_gas=GAS_REQUIRED_FOR_SETTLE_CHANNEL,
             block_identifier=block,
         )

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2229,14 +2229,14 @@ class TokenNetwork:
                 self.client.poll(transaction_hash)
                 transaction_error = check_transaction_threw(self.client, transaction_hash)
 
-        self.validate_settlement_transaction_error(channel_identifier,
-                                                   checking_block,
-                                                   error_prefix,
-                                                   log_details,
-                                                   partner,
-                                                   transaction_error,
-                                                   False,
-                                                   gas_limit)
+        self.validate_settlement_transaction_error(channel_identifier=channel_identifier,
+                                                   checking_block=checking_block,
+                                                   error_prefix=error_prefix,
+                                                   log_details=log_details,
+                                                   partner=partner,
+                                                   transaction_error=transaction_error,
+                                                   is_light=False,
+                                                   gas_limit=gas_limit)
 
         log.info("settle successful", **log_details)
 
@@ -2274,13 +2274,13 @@ class TokenNetwork:
             self.client.poll(transaction_hash)
             transaction_error = check_transaction_threw(self.client, transaction_hash)
 
-        self.validate_settlement_transaction_error(channel_identifier,
-                                                   checking_block,
-                                                   "settle call failed",
-                                                   log_details,
-                                                   partner,
-                                                   transaction_error,
-                                                   True)
+        self.validate_settlement_transaction_error(channel_identifier=channel_identifier,
+                                                   checking_block=checking_block,
+                                                   error_prefix="settle call failed",
+                                                   log_details=log_details,
+                                                   partner=partner,
+                                                   transaction_error=transaction_error,
+                                                   is_light=True)
 
         log.info("settle light successful", **log_details)
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2285,14 +2285,14 @@ class TokenNetwork:
         log.info("settle light successful", **log_details)
 
     def validate_settlement_transaction_error(self,
-                                              channel_identifier,
-                                              checking_block,
-                                              error_prefix,
-                                              log_details,
-                                              partner,
+                                              channel_identifier: ChannelID,
+                                              checking_block: BlockNumber,
+                                              error_prefix: str,
+                                              log_details: Dict,
+                                              partner: Address,
                                               transaction_error,
-                                              is_light,
-                                              gas_limit=None):
+                                              is_light: bool,
+                                              gas_limit: int = None):
         transaction_executed = is_light or gas_limit is not None
         if not transaction_executed or transaction_error:
             if transaction_error["blockNumber"]:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -667,11 +667,11 @@ class RaidenEventHandler(EventHandler):
 
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
 
-        # and now find out
+        # and now find out our maximum and the partner maximum to compare and figure out which is higher
         our_maximum = settlement_parameters.transferred_amount + settlement_parameters.locked_amount
         partner_maximum = settlement_parameters.partner_transferred_amount + settlement_parameters.partner_locked_amount
 
-        # The second participant transferred + locked amount must be higher
+        # The second participant transferred + locked amount must be higher by contract requirement
         our_bp_is_larger = our_maximum > partner_maximum
         if our_bp_is_larger:
             message = SettlementRequiredLightMessage (

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -734,7 +734,6 @@ class RaidenEventHandler(EventHandler):
             token_network_address=token_network_identifier,
             channel_identifier=channel_identifier,
         )
-        triggered_by_block_hash = triggered_by_block_hash
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
             canonical_identifier=canonical_identifier
         )

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -643,6 +643,8 @@ class RaidenEventHandler(EventHandler):
                                                   channel_settle_light_event: ContractSendChannelSettleLight):
         """ Store a message for the LC with SettlementRequired type to handle settlement for LC on hub mode. """
 
+        log.debug("Handling channel settle light")
+
         settlement_parameters = RaidenEventHandler.process_data_and_get_settlement_parameters(
             raiden,
             channel_settle_light_event.token_network_identifier,
@@ -693,6 +695,8 @@ class RaidenEventHandler(EventHandler):
                 participant2_locked_amount=settlement_parameters.partner_locked_amount,
                 participant2_locksroot=settlement_parameters.partner_locksroot)
 
+        log.debug("Storing light client message to require settle")
+
         LightClientMessageHandler\
             .store_light_client_protocol_message(identifier=message_identifier,
                                                  message=message,
@@ -708,6 +712,9 @@ class RaidenEventHandler(EventHandler):
                                                    token_network_identifier: TokenNetworkID,
                                                    channel_identifier: ChannelID,
                                                    triggered_by_block_hash: BlockHash) -> SettlementParameters:
+
+        log.debug("Processing settlement data")
+
         assert raiden.wal, "The Raiden Service must be initialize to handle events"
         canonical_identifier = CanonicalIdentifier(
             chain_identifier=raiden.chain.network_id,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -697,15 +697,28 @@ class RaidenEventHandler(EventHandler):
 
         log.debug("Storing light client message to require settle")
 
-        LightClientMessageHandler\
-            .store_light_client_protocol_message(identifier=message_identifier,
-                                                 message=message,
-                                                 signed=False,
-                                                 payment_id=None,
-                                                 light_client_address=payment_channel.participant1,
-                                                 order=0,
-                                                 message_type=LightClientProtocolMessageType.SettlementRequired,
-                                                 wal=raiden.wal)
+        message_already_stored = LightClientMessageHandler.is_message_already_stored(
+            light_client_address=payment_channel.participant1,
+            message_type=LightClientProtocolMessageType.SettlementRequired,
+            unsigned_message=message,
+            wal=raiden.wal)
+
+        if message_already_stored:
+            log.debug(
+                "Skipping storing light client settle message "
+                "for {} with type {} since already exists in database".format(
+                    payment_channel.participant1.hex(),
+                    str(LightClientProtocolMessageType.SettlementRequired)))
+        else:
+            LightClientMessageHandler \
+                .store_light_client_protocol_message(identifier=message_identifier,
+                                                     message=message,
+                                                     signed=False,
+                                                     payment_id=None,
+                                                     light_client_address=payment_channel.participant1,
+                                                     order=0,
+                                                     message_type=LightClientProtocolMessageType.SettlementRequired,
+                                                     wal=raiden.wal)
 
     @staticmethod
     def process_data_and_get_settlement_parameters(raiden: "RaidenService",

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -32,7 +32,8 @@ from raiden.transfer.events import (
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
     SendProcessed,
-    ContractSendChannelUpdateTransferLight, ContractSendChannelSettleLight)
+    ContractSendChannelUpdateTransferLight,
+    ContractSendChannelSettleLight)
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockClaimFailed,
@@ -617,13 +618,15 @@ class RaidenEventHandler(EventHandler):
             raiden,
             channel_settle_event.token_network_identifier,
             channel_settle_event.channel_identifier,
-            channel_settle_event.triggered_by_block_hash)
+            channel_settle_event.triggered_by_block_hash
+        )
 
         canonical_identifier = CanonicalIdentifier(
             chain_identifier=raiden.chain.network_id,
             token_network_address=channel_settle_event.token_network_identifier,
             channel_identifier=channel_settle_event.channel_identifier,
         )
+
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
             canonical_identifier=canonical_identifier
         )

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -728,7 +728,7 @@ class RaidenEventHandler(EventHandler):
 
         log.debug("Processing settlement data")
 
-        assert raiden.wal, "The Raiden Service must be initialize to handle events"
+        assert raiden.wal, "The Raiden Service must be initialized to handle events"
         canonical_identifier = CanonicalIdentifier(
             chain_identifier=raiden.chain.network_id,
             token_network_address=token_network_identifier,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1325,11 +1325,11 @@ class RaidenService(Runnable):
                 delivered.delivered_message_identifier,
                 delivered,
                 True,
-                payment_id,
                 sender_address,
                 msg_order,
                 message_type,
-                self.wal
+                self.wal,
+                payment_id
             )
             lc_transport.send_for_light_client_with_retry(receiver_address, delivered)
 
@@ -1342,11 +1342,11 @@ class RaidenService(Runnable):
                 processed.message_identifier,
                 processed,
                 True,
-                payment_id,
                 sender_address,
                 msg_order,
                 message_type,
-                self.wal
+                self.wal,
+                payment_id
             )
             lc_transport.send_for_light_client_with_retry(receiver_address, processed)
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -11,7 +11,7 @@ from raiden.lightclient.models.client_model import ClientType
 from raiden.storage.serialize import SerializationBase
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import get_system_spec
-from raiden.utils.typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union, AddressHex
+from raiden.utils.typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
 from dateutil.relativedelta import relativedelta
 
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -1375,14 +1375,14 @@ class SQLiteStorage:
     def get_light_client_messages(self, from_message, light_client):
         cursor = self.conn.cursor()
         cursor.execute(
-            "SELECT identifier, message_order, unsigned_message, signed_message, light_client_payment_id, internal_msg_identifier, message_type" +
-            " FROM light_client_protocol_message A INNER JOIN light_client_payment B" +
-            " ON A.light_client_payment_id = B.payment_id" +
-            " WHERE A.internal_msg_identifier >= ?" +
-            " AND A.light_client_address = ?" +
-            "ORDER BY light_client_payment_id, message_order ASC",
+            """
+            SELECT identifier, message_order, unsigned_message, signed_message, light_client_payment_id, internal_msg_identifier, message_type
+            FROM light_client_protocol_message
+            WHERE internal_msg_identifier >= ?
+            AND light_client_address = ?
+            ORDER BY light_client_payment_id, message_order ASC
+            """,
             (from_message, light_client),
-
         )
         return cursor.fetchall()
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -26,7 +26,8 @@ from raiden.transfer.events import (
     EventInvalidReceivedTransferRefund,
     EventInvalidReceivedUnlock,
     SendProcessed,
-    ContractSendChannelUpdateTransferLight, ContractSendChannelSettleLight)
+    ContractSendChannelUpdateTransferLight,
+    ContractSendChannelSettleLight)
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
     CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
@@ -1827,7 +1828,6 @@ def handle_block(
             )
 
             if channel_state.is_light_channel:
-                # get which of the participants is the lc to differentiate the address
                 event = ContractSendChannelSettleLight(
                     canonical_identifier=channel_state.canonical_identifier,
                     triggered_by_block_hash=state_change.block_hash,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -165,6 +165,21 @@ class ContractSendChannelSettle(ContractSendEvent):
         return restored
 
 
+class ContractSendChannelSettleLight(ContractSendChannelSettle):
+    """ Event emitted if the netting channel must be settled for light clients. """
+
+    def __init__(
+        self,
+        canonical_identifier: CanonicalIdentifier,
+        triggered_by_block_hash: BlockHash,
+        channel_state: NettingChannelState
+    ):
+        super().__init__(
+            canonical_identifier=canonical_identifier,
+            triggered_by_block_hash=triggered_by_block_hash,
+            channel_state=channel_state)
+
+
 class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     """ Event emitted if the netting channel balance proof must be updated. """
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -638,41 +638,6 @@ def filter_channels_by_partneraddress(
     return result
 
 
-def filter_channels_to_settle_by_partner_address(
-    chain_state: ChainState,
-    payment_network_id: PaymentNetworkID,
-    token_address: TokenAddress,
-    partner_addresses: List[Address],
-) -> List[NettingChannelState]:
-    token_network = get_token_network_by_token_address(
-        chain_state, payment_network_id, token_address
-    )
-
-    result: List[NettingChannelState] = []
-    if not token_network:
-        return result
-
-    channelsResult = []
-    # for partner in partner_addresses:
-
-    for node_address in token_network.partneraddresses_to_channelidentifiers.keys():
-        if node_address in token_network.channelidentifiers_to_channels:
-            channels = token_network.channelidentifiers_to_channels[node_address]
-            if channels is not None:
-                for _channelId, channel in channels.items():
-                    for partner_address in partner_addresses:
-                        if channel.partner_state.address == partner_address:
-                            if channel.close_transaction and channel.close_transaction.result == 'success':
-                                channelsResult.append(channel)
-
-    states = filter_channels_by_status(channelsResult, [CHANNEL_STATE_SETTLING])
-    # If multiple channel states are found, return the last one.
-    if states:
-        result.append(states[-1])
-
-    return result
-
-
 def filter_channels_by_status(
     channel_states: List[NettingChannelState], exclude_states: Optional[List[str]] = None
 ) -> List[NettingChannelState]:

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -638,6 +638,41 @@ def filter_channels_by_partneraddress(
     return result
 
 
+def filter_channels_to_settle_by_partner_address(
+    chain_state: ChainState,
+    payment_network_id: PaymentNetworkID,
+    token_address: TokenAddress,
+    partner_addresses: List[Address],
+) -> List[NettingChannelState]:
+    token_network = get_token_network_by_token_address(
+        chain_state, payment_network_id, token_address
+    )
+
+    result: List[NettingChannelState] = []
+    if not token_network:
+        return result
+
+    channelsResult = []
+    # for partner in partner_addresses:
+
+    for node_address in token_network.partneraddresses_to_channelidentifiers.keys():
+        if node_address in token_network.channelidentifiers_to_channels:
+            channels = token_network.channelidentifiers_to_channels[node_address]
+            if channels is not None:
+                for _channelId, channel in channels.items():
+                    for partner_address in partner_addresses:
+                        if channel.partner_state.address == partner_address:
+                            if channel.close_transaction and channel.close_transaction.result == 'success':
+                                channelsResult.append(channel)
+
+    states = filter_channels_by_status(channelsResult, [CHANNEL_STATE_SETTLING])
+    # If multiple channel states are found, return the last one.
+    if states:
+        result.append(states[-1])
+
+    return result
+
+
 def filter_channels_by_status(
     channel_states: List[NettingChannelState], exclude_states: Optional[List[str]] = None
 ) -> List[NettingChannelState]:

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -422,6 +422,7 @@ def get_channelstate_filter(
     payment_network_id: PaymentNetworkID,
     token_address: TokenAddress,
     filter_fn: Callable,
+    creator_address=None
 ) -> List[NettingChannelState]:
     """ Return the state of channels that match the condition in `filter_fn` """
     token_network = get_token_network_by_token_address(
@@ -432,8 +433,11 @@ def get_channelstate_filter(
     if not token_network:
         return result
 
-    if chain_state.our_address in token_network.channelidentifiers_to_channels:
-        for channel_state in token_network.channelidentifiers_to_channels[chain_state.our_address].values():
+    if not creator_address:
+        creator_address = chain_state.our_address
+
+    if creator_address in token_network.channelidentifiers_to_channels:
+        for channel_state in token_network.channelidentifiers_to_channels[creator_address].values():
             if filter_fn(channel_state):
                 result.append(channel_state)
 
@@ -477,7 +481,7 @@ def get_channelstate_closed(
 
 
 def get_channelstate_settling(
-    chain_state: ChainState, payment_network_id: PaymentNetworkID, token_address: TokenAddress
+    chain_state: ChainState, payment_network_id: PaymentNetworkID, token_address: TokenAddress, creator_address=None
 ) -> List[NettingChannelState]:
     """Return the state of settling channels in a token network."""
     return get_channelstate_filter(
@@ -485,6 +489,7 @@ def get_channelstate_settling(
         payment_network_id,
         token_address,
         lambda channel_state: channel.get_status(channel_state) == CHANNEL_STATE_SETTLING,
+        creator_address=creator_address
     )
 
 


### PR DESCRIPTION
This PR introduces the ability to execute the settlement process from light clients.

Here we are:

* Adding the new event to handle for LC's
* Refactoring store_light_client_protocol_message to put payment_id as optional at the end of the arguments since it's an optional parameter on the database
* Adding the event handler for the ContractSendChannelSettleLight event
* Refactoring the method handle_contract_send_channelsettle to encapsulate the logic in an internal method to reuse that logic for light settlement, basically we use the same parameters to handle the operation
* Adding SettlementParameters object to encapsulate the parameters generated by process_data_and_get_settlement_parameters
* Adding a new type of message to store for LC's
* Adding logic to patch_light_channel to handle settle with a signed settle transaction
* Adding handle method for that logic
* Adding handle method for settle in payment channel proxy
* Adding handle method for settle in token network proxy
* Adding view and method to validate requests for settle

Now a light client will be able to settle a channel after the channel is closed and ready for settle.

Test results:

```
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-5.2.0, py-1.9.0, pluggy-0.13.1
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/jonathan/workspace/rsk/lumino-settlement/.hypothesis/examples')
rootdir: /home/jonathan/workspace/rsk/lumino-settlement, inifile: setup.cfg
plugins: random-0.2, select-0.1.2, hypothesis-3.88.3, timeout-1.3.3, cov-2.5.1
timeout: 540.0s
timeout method: signal
timeout func_only: False
collected 659 items

raiden/tests/test_message_delivered.py .                                 [  0%]
raiden/tests/fuzz/test_state_changes.py FF.FFFFs                         [  1%]
raiden/tests/integration/test_balance_proof_check.py ..                  [  1%]
raiden/tests/integration/test_blockchainservice.py .                     [  1%]
raiden/tests/integration/test_echo_node.py sss                           [  2%]
raiden/tests/integration/test_pythonapi_base.py .....s......             [  4%]
raiden/tests/integration/test_raidenservice.py .X                        [  4%]
raiden/tests/integration/test_recovery.py sss                            [  4%]
raiden/tests/integration/test_regression.py .F..                         [  5%]
raiden/tests/integration/test_regression_parity.py s                     [  5%]
raiden/tests/integration/test_send_queued_messages.py ..                 [  5%]
raiden/tests/integration/api/test_pythonapi.py .....s......              [  7%]
raiden/tests/integration/api/test_pythonapi_regression.py .              [  7%]
raiden/tests/integration/api/test_restapi.py ...x....................... [ 11%]
..........                                                               [ 13%]
raiden/tests/integration/cli/test_cli_development.py ss                  [ 13%]
raiden/tests/integration/cli/test_cli_production.py sssssss              [ 14%]
raiden/tests/integration/long_running/test_integration_events.py .....   [ 15%]
raiden/tests/integration/long_running/test_settlement.py F.F..xx..       [ 16%]
raiden/tests/integration/long_running/test_stress.py s                   [ 16%]
raiden/tests/integration/long_running/test_token_networks.py F           [ 17%]
raiden/tests/integration/network/proxies/test_discovery.py ..            [ 17%]
raiden/tests/integration/network/proxies/test_payment_channel.py .       [ 17%]
raiden/tests/integration/network/proxies/test_secret_registry.py ....    [ 18%]
raiden/tests/integration/network/proxies/test_service_registry.py ..     [ 18%]
raiden/tests/integration/network/proxies/test_token.py .                 [ 18%]
raiden/tests/integration/network/proxies/test_token_network.py .....     [ 19%]
raiden/tests/integration/network/proxies/test_token_network_registry.py . [ 19%]
                                                                         [ 19%]
raiden/tests/integration/network/transport/test_matrix_transport.py .... [ 20%]
.......F....ss.................x..                                       [ 25%]
raiden/tests/integration/network/transport/test_udp.py ss.               [ 25%]
raiden/tests/integration/rpc/test_client.py .                            [ 25%]
raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py s [ 26%]
                                                                         [ 26%]
raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py .. [ 26%]
..                                                                       [ 26%]
raiden/tests/integration/rpc/assumptions/test_rpc_filters_assumptions.py . [ 26%]
.                                                                        [ 27%]
raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py . [ 27%]
.                                                                        [ 27%]
raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py . [ 27%]
.                                                                        [ 27%]
raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py . [ 27%]
..                                                                       [ 28%]
raiden/tests/integration/transfer/test_mediatedtransfer.py ....sss       [ 29%]
raiden/tests/integration/transfer/test_mediatedtransfer_events.py .      [ 29%]
raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py ..... [ 30%]
.                                                                        [ 30%]
raiden/tests/integration/transfer/test_refund_invalid.py .               [ 30%]
raiden/tests/integration/transfer/test_refundtransfer.py ....            [ 30%]
raiden/tests/unit/test_accounts.py ......                                [ 31%]
raiden/tests/unit/test_binary_encoding.py .............................. [ 36%]
......................                                                   [ 39%]
raiden/tests/unit/test_case_utils.py ......                              [ 40%]
raiden/tests/unit/test_channelstate.py .............................     [ 45%]
raiden/tests/unit/test_cli.py .............                              [ 47%]
raiden/tests/unit/test_dict_encoding.py ................................ [ 51%]
................                                                         [ 54%]
raiden/tests/unit/test_light_client_messages.py .........                [ 55%]
raiden/tests/unit/test_lightclient_onboarding.py ........                [ 56%]
raiden/tests/unit/test_logging.py ...................................... [ 62%]
.                                                                        [ 62%]
raiden/tests/unit/test_matrix_presence.py .....                          [ 63%]
raiden/tests/unit/test_matrix_transport_unit.py ......                   [ 64%]
raiden/tests/unit/test_message_locked_transfer.py ....                   [ 65%]
raiden/tests/unit/test_messages.py .....                                 [ 65%]
raiden/tests/unit/test_mock.py .                                         [ 66%]
raiden/tests/unit/test_mtree.py .....                                    [ 66%]
raiden/tests/unit/test_namedbuffer.py .....                              [ 67%]
raiden/tests/unit/test_node_queue.py ...                                 [ 67%]
raiden/tests/unit/test_notifyingqueue.py ...                             [ 68%]
raiden/tests/unit/test_operators.py ...                                  [ 68%]
raiden/tests/unit/test_pfs_integration.py ...................            [ 71%]
raiden/tests/unit/test_raiden_event_handler.py .                         [ 71%]
raiden/tests/unit/test_rpc.py .                                          [ 72%]
raiden/tests/unit/test_serialization.py ........                         [ 73%]
raiden/tests/unit/test_signature_lc.py .                                 [ 73%]
raiden/tests/unit/test_sqlite.py .....                                   [ 74%]
raiden/tests/unit/test_startup.py ..................                     [ 76%]
raiden/tests/unit/test_state.py ..                                       [ 77%]
raiden/tests/unit/test_tokennetwork.py ...F....                          [ 78%]
raiden/tests/unit/test_udp_transport.py ssss                             [ 79%]
raiden/tests/unit/test_upgrade.py .....                                  [ 79%]
raiden/tests/unit/test_version_check.py ...                              [ 80%]
raiden/tests/unit/test_wal.py .......                                    [ 81%]
raiden/tests/unit/api/test_api.py ....                                   [ 81%]
raiden/tests/unit/api/test_api_events.py ...                             [ 82%]
raiden/tests/unit/storage/test_storage.py ....                           [ 83%]
raiden/tests/unit/storage/test_versions.py ..                            [ 83%]
raiden/tests/unit/storage/migrations/test_v16_to_v17.py .                [ 83%]
raiden/tests/unit/storage/migrations/test_v17_to_v18.py .                [ 83%]
raiden/tests/unit/storage/migrations/test_v18_to_v19.py .                [ 83%]
raiden/tests/unit/storage/migrations/test_v19_to_v20.py .                [ 83%]
raiden/tests/unit/storage/migrations/test_v20_to_v21.py .                [ 84%]
raiden/tests/unit/storage/migrations/test_v21_to_v22.py .                [ 84%]
raiden/tests/unit/transfer/test_channel.py ....                          [ 84%]
raiden/tests/unit/transfer/test_node.py .                                [ 84%]
raiden/tests/unit/transfer/test_utils.py .....                           [ 85%]
raiden/tests/unit/transfer/mediated_transfer/test_events.py .            [ 85%]
raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py .... [ 86%]
.........................                                                [ 90%]
raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py ..... [ 91%]
F.....F.......F.........F.......F.....                                   [ 96%]
raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py . [ 96%]
F.FFF.                                                                   [ 97%]
raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py ....... [ 98%]
......x                                                                  [100%]
= 21 failed, 601 passed, 32 skipped, 5 xfailed, 1 xpassed, 9 warnings in 9527.27s (2:38:47) =
```

Here the entire log for testing:

[tests.log](https://github.com/rsksmart/lumino/files/5269264/tests.log)

