### PR TITLE
RLP-790: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 *,cover
 .pytest_cache/
 mypy-out.txt
+*.hypothesis/
 
 # Pyenv
 .python-version
@@ -84,7 +85,7 @@ raiden-debug_*.log
 
 # venvs
 venv/
-clientEnv/
+*Env/
 
 # test keystores
 keystores
@@ -94,5 +95,3 @@ keystores
 
 # raiden logs
 raiden/raiden-*
-
-


### PR DESCRIPTION
This PR updates the `.gitignore` file in the following ways:
- all folders ending in `Env` (e.g. `clientEnv`, `testEnv`) will be ignored.
- all folders ending in `.hypothesis` will be ignored.