### PR TITLE
RLP-775: fixes to transport generalization, wave 1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -64,7 +64,7 @@ semantic-version==2.6.0
 semver==2.8.1
 simplegeneric==0.8.1
 six==1.11.0
-structlog==18.2.0
+structlog==20.1.0
 toolz==0.9.0
 traitlets==4.3.2
 urllib3==1.23

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -254,13 +254,13 @@ class _RetryQueue(Runnable):
 class MatrixTransport(TransportLayer, Runnable):
     _room_prefix = "raiden"
     _room_sep = "_"
+    log = log
 
     def __init__(self, address: Address, config: dict, current_server_name: str = None):
         TransportLayer.__init__(self, address)
         Runnable.__init__(self)
         self._config = config
         self._raiden_service: Optional[RaidenService] = None
-        self.log = log
 
         available_servers = get_available_servers_from_config(self._config)
 
@@ -1735,6 +1735,7 @@ class MatrixLightClientTransport(MatrixTransport):
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):
             self.log.warning("Exception while processing message", exc_info=True)
             return
+
 
 class NodeTransport:
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -254,13 +254,13 @@ class _RetryQueue(Runnable):
 class MatrixTransport(TransportLayer, Runnable):
     _room_prefix = "raiden"
     _room_sep = "_"
-    log = log
 
     def __init__(self, address: Address, config: dict, current_server_name: str = None):
         TransportLayer.__init__(self, address)
         Runnable.__init__(self)
         self._config = config
         self._raiden_service: Optional[RaidenService] = None
+        self.log = log
 
         available_servers = get_available_servers_from_config(self._config)
 
@@ -1337,10 +1337,10 @@ class MatrixTransport(TransportLayer, Runnable):
         return True
 
     def link_exception(self, callback: Any):
-        Runnable.link_exception(self, callback)
+        self.greenlet.link_exception(callback)
 
     def join(self, timeout=None):
-        Runnable.join(self, timeout)
+        self.greenlet.join(timeout)
 
 
 class MatrixLightClientTransport(MatrixTransport):

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -63,6 +63,7 @@ def matrix_transports(
         server = local_matrix_servers[transport_index % len(local_matrix_servers)]
         transports.append(
             MatrixTransport(
+                bytearray(),  # must be set before starting the transport
                 {
                     "global_rooms": global_rooms,
                     "retries_before_backoff": retries_before_backoff,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -1,5 +1,3 @@
-
-
 import random
 
 import gevent
@@ -947,4 +945,3 @@ def run_test_batch_unlock_after_restart(raiden_network, token_addresses, deposit
             participant=alice_bob_channel_state.partner_state.address,
             partner=alice_bob_channel_state.our_state.address,
         )
-

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -446,7 +446,12 @@ def test_matrix_message_retry(
     message = Processed(message_identifier=0)
     transport._raiden_service.sign(message)
     chain_state.queueids_to_queues[queueid] = [message]
-    retry_queue.enqueue_global(message)
+    retry_queue.enqueue(
+        queue_identifier=QueueIdentifier(
+            recipient=retry_queue.receiver, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
+        ),
+        message=message
+    )
 
     gevent.sleep(1)
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -406,8 +406,10 @@ def test_matrix_message_retry(
     the receiver comes back again, the message should be sent again.
     """
     partner_address = factories.make_address()
+    raiden_service = MockRaidenService(None)
 
     transport = MatrixTransport(
+        address=raiden_service.address,
         config={
             "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
@@ -419,7 +421,6 @@ def test_matrix_message_retry(
         },
     )
     transport._send_raw = MagicMock()
-    raiden_service = MockRaidenService(None)
 
     transport.start(raiden_service, raiden_service.message_handler, None)
     transport.log = MagicMock()
@@ -485,7 +486,9 @@ def test_join_invalid_discovery(
     to be handled, and if no discovery room is found on any of the available_servers, one in
     our current server should be created
     """
+    raiden_service = MockRaidenService(None)
     transport = MatrixTransport(
+        raiden_service.address,
         {
             "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
@@ -498,7 +501,6 @@ def test_join_invalid_discovery(
     )
     transport._client.api.retry_timeout = 0
     transport._send_raw = MagicMock()
-    raiden_service = MockRaidenService(None)
 
     transport.start(raiden_service, raiden_service.message_handler, None)
     transport.log = MagicMock()
@@ -549,8 +551,9 @@ def test_matrix_cross_server_with_load_balance(matrix_transports):
 def test_matrix_discovery_room_offline_server(
     local_matrix_servers, retries_before_backoff, retry_interval, private_rooms, global_rooms
 ):
-
+    raiden_service = MockRaidenService(None)
     transport = MatrixTransport(
+        raiden_service.address,
         {
             "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
@@ -561,7 +564,7 @@ def test_matrix_discovery_room_offline_server(
             "private_rooms": private_rooms,
         }
     )
-    transport.start(MockRaidenService(None), MessageHandler(set()), "")
+    transport.start(raiden_service, MessageHandler(set()), "")
     gevent.sleep(0.2)
 
     discovery_room_name = make_room_alias(transport.network_id, "discovery")
@@ -574,7 +577,9 @@ def test_matrix_discovery_room_offline_server(
 def test_matrix_send_global(
     local_matrix_servers, retries_before_backoff, retry_interval, private_rooms, global_rooms
 ):
+    raiden_service = MockRaidenService(None)
     transport = MatrixTransport(
+        raiden_service.address,
         {
             "global_rooms": global_rooms + [MONITORING_BROADCASTING_ROOM],
             "retries_before_backoff": retries_before_backoff,
@@ -585,7 +590,7 @@ def test_matrix_send_global(
             "private_rooms": private_rooms,
         }
     )
-    transport.start(MockRaidenService(None), MessageHandler(set()), "")
+    transport.start(raiden_service, MessageHandler(set()), "")
     gevent.idle()
 
     ms_room_name = make_room_alias(transport.network_id, MONITORING_BROADCASTING_ROOM)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -79,6 +79,8 @@ def mock_matrix(
         # We are just unit testing the matrix transport receive so do nothing
         assert message
 
+    raiden_service = MockRaidenService()
+
     config = dict(
         retry_interval=retry_interval,
         retries_before_backoff=retries_before_backoff,
@@ -89,8 +91,8 @@ def mock_matrix(
         private_rooms=private_rooms,
     )
 
-    transport = MatrixTransport(config)
-    transport._raiden_service = MockRaidenService()
+    transport = MatrixTransport(raiden_service.address, config)
+    transport._raiden_service = raiden_service
     transport._stop_event.clear()
     transport._address_mgr.add_userid_for_address(factories.HOP1, USERID1)
     transport._client.user_id = USERID0

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -309,6 +309,8 @@ def test_matrix_message_sync(matrix_transports):
 
     raiden_service1.handle_and_track_state_change = MagicMock()
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, message_handler, None)
     transport1.start(raiden_service1, message_handler, None)
 
@@ -529,6 +531,9 @@ def test_matrix_cross_server_with_load_balance(matrix_transports):
     raiden_service1 = MockRaidenService(message_handler1)
     raiden_service2 = MockRaidenService(message_handler2)
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
+    transport2._address = raiden_service2.address
     transport0.start(raiden_service0, message_handler0, "")
     transport1.start(raiden_service1, message_handler1, "")
     transport2.start(raiden_service2, message_handler2, "")
@@ -752,6 +757,8 @@ def test_matrix_invite_private_room_happy_case(matrix_transports, expected_join_
 
     transport0, transport1 = matrix_transports
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, raiden_service0.message_handler, None)
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
@@ -811,6 +818,8 @@ def test_matrix_invite_private_room_unhappy_case1(
 
     transport0, transport1 = matrix_transports
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, raiden_service0.message_handler, None)
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
@@ -870,6 +879,8 @@ def test_matrix_invite_private_room_unhappy_case_2(
 
     transport0, transport1 = matrix_transports
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, raiden_service0.message_handler, None)
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
@@ -940,6 +951,8 @@ def test_matrix_invite_private_room_unhappy_case_3(matrix_transports, expected_j
 
     transport0, transport1 = matrix_transports
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, raiden_service0.message_handler, None)
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
@@ -990,6 +1003,8 @@ def test_matrix_user_roaming(matrix_transports):
     raiden_service0 = MockRaidenService(message_handler0)
     raiden_service1 = MockRaidenService(message_handler1)
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, message_handler0, "")
     transport1.start(raiden_service1, message_handler1, "")
 
@@ -1005,6 +1020,7 @@ def test_matrix_user_roaming(matrix_transports):
 
     assert not is_reachable(transport1, raiden_service0.address)
 
+    transport2._address = raiden_service0.address
     transport2.start(raiden_service0, message_handler0, "")
 
     transport2.start_health_check(raiden_service1.address)
@@ -1018,6 +1034,7 @@ def test_matrix_user_roaming(matrix_transports):
 
     assert not is_reachable(transport1, raiden_service0.address)
 
+    transport0._address = raiden_service0.address
     transport0.start(raiden_service0, message_handler0, "")
     with Timeout(40):
         while not is_reachable(transport1, raiden_service0.address):
@@ -1045,6 +1062,8 @@ def test_matrix_multi_user_roaming(matrix_transports):
     raiden_service1 = MockRaidenService(message_handler1)
 
     # Both nodes on the same server
+    transport0._address = raiden_service0.address
+    transport3._address = raiden_service1.address
     transport0.start(raiden_service0, message_handler0, "")
     transport3.start(raiden_service1, message_handler1, "")
 
@@ -1056,6 +1075,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two switches to second server
     transport3.stop()
 
+    transport4._address = raiden_service1.address
     transport4.start(raiden_service1, message_handler1, "")
     transport4.start_health_check(raiden_service0.address)
     gevent.sleep(0.5)
@@ -1065,6 +1085,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two switches to third server
     transport4.stop()
 
+    transport5._address = raiden_service1.address
     transport5.start(raiden_service1, message_handler1, "")
     transport5.start_health_check(raiden_service0.address)
     gevent.sleep(0.5)
@@ -1073,8 +1094,10 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node one switches to second server, Node two back to first
     transport0.stop()
     transport5.stop()
+    transport1._address = raiden_service0.address
     transport1.start(raiden_service0, message_handler0, "")
     transport1.start_health_check(raiden_service1.address)
+    transport3._address = raiden_service1.address
     transport3.start(raiden_service1, message_handler1, "")
     gevent.sleep(0.5)
 
@@ -1083,6 +1106,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two joins on second server again
     transport3.stop()
 
+    transport4._address = raiden_service1.address
     transport4.start(raiden_service1, message_handler1, "")
     gevent.sleep(0.5)
 
@@ -1091,6 +1115,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two switches to third server
     transport4.stop()
 
+    transport5._address = raiden_service1.address
     transport5.start(raiden_service1, message_handler1, "")
     gevent.sleep(0.5)
 
@@ -1100,8 +1125,10 @@ def test_matrix_multi_user_roaming(matrix_transports):
     transport1.stop()
     transport5.stop()
 
+    transport2._address = raiden_service0.address
     transport2.start(raiden_service0, message_handler0, "")
     transport2.start_health_check(raiden_service1.address)
+    transport3._address = raiden_service1.address
     transport3.start(raiden_service1, message_handler1, "")
     gevent.sleep(0.5)
 
@@ -1110,6 +1137,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two switches to second server
 
     transport3.stop()
+    transport4._address = raiden_service1.address
     transport4.start(raiden_service1, message_handler1, "")
 
     gevent.sleep(0.5)
@@ -1118,6 +1146,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
     # Node two joins on third server
 
     transport4.stop()
+    transport5._address = raiden_service1.address
     transport5.start(raiden_service1, message_handler1, "")
 
     gevent.sleep(0.5)
@@ -1138,6 +1167,8 @@ def test_reproduce_handle_invite_send_race_issue_3588(matrix_transports):
     raiden_service0 = MockRaidenService(message_handler0)
     raiden_service1 = MockRaidenService(message_handler1)
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, message_handler0, "")
     transport1.start(raiden_service1, message_handler1, "")
 
@@ -1160,6 +1191,8 @@ def test_send_to_device(matrix_transports):
     raiden_service1 = MockRaidenService(message_handler1)
     transport1._receive_to_device = MagicMock()
 
+    transport0._address = raiden_service0.address
+    transport1._address = raiden_service1.address
     transport0.start(raiden_service0, message_handler0, "")
     transport1.start(raiden_service1, message_handler1, "")
 

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -203,7 +203,7 @@ def run_test_payment_statuses_are_restored(raiden_network, token_addresses, netw
         default_secret_registry=app0.raiden.default_secret_registry,
         default_service_registry=app0.raiden.default_service_registry,
         default_one_to_n_address=app0.raiden.default_one_to_n_address,
-        transport=MatrixTransport(app0.raiden.config["transport"]["matrix"]),
+        transport=MatrixTransport(app0.raiden.config["address"], app0.raiden.config["transport"]["matrix"]),
         raiden_event_handler=raiden_event_handler,
         message_handler=message_handler,
         discovery=app0.raiden.discovery,

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytoml==0.1.19
 raiden-contracts==0.19.1
 raiden-webui==0.8.0
 requests==2.20.0
-structlog==18.2.0
+structlog==20.1.0
 webargs==5.1.3
 python-dateutil==2.8.0
 apscheduler==3.6.0


### PR DESCRIPTION
This PR is the first wave of fixes for [the ongoing transport generalization PR](https://github.com/rsksmart/lumino/pull/110).

The objective here is to fix bugs introduced in said PR, but which are already evident based on the execution of the test suite. This was done based on [the `develop` test baseline](https://jirainfuy.atlassian.net/browse/RLP-760).

After this is merged, manual verifications should take place in order to then continue with PR #114 (and the rest of the transport tasks).

### Changes
- some unit tests had to be fixed, mainly due to `MatrixTransport` requiring an `address` field when initialized. these weren't business logic failures, but rather test code exceptions.
- the `MatrixTransport` implementation of the `link_exception` and `join` methods just flat out [didn't work](https://github.com/rsksmart/lumino/pull/120/files#r489537045). this **was a breaking failure.**
- the `structlog` dependency is bumped up to a more recent version due to a [nasty bug](https://github.com/rsksmart/lumino/pull/120#discussion_r489418906). this was also going to crash the node.
- some minor formatting changes were applied.

more in-depth details can be found in the diff section, as comments.

---

Wave 1 for issue [RLP-755](https://jirainfuy.atlassian.net/browse/RLP-775).