### PR TITLE
Fixing support for Lumino node to run without prompt

### DIFF
--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -183,7 +183,7 @@ def get_account_and_private_key(
         address_hex = to_normalized_address(address)
 
     if password_file:
-        privatekey_bin = unlock_account_with_passwordfile(
+        privatekey_bin, pubkey_bin = unlock_account_with_passwordfile(
             account_manager=account_manager, address_hex=address_hex, password_file=password_file
         )
     else:

--- a/raiden/ui/prompt.py
+++ b/raiden/ui/prompt.py
@@ -35,7 +35,7 @@ def unlock_account_with_passwordfile(
     password = password_file.read().strip("\r\n")
 
     try:
-        return account_manager.get_privkey(address_hex, password.strip())
+        return account_manager.get_privkey_and_pubkey(address_hex, password.strip())
     except ValueError:
         click.secho(f"Incorrect password for {address_hex} in file. Aborting ...", fg="red")
         sys.exit(1)


### PR DESCRIPTION
In this PR we are:

* Fixing getting the private key and public key from password file option

This allows to use the --address and --password-file options to avoid the prompt when lumino starts.