### PR TITLE
RLP-814: fix test suite dependencies

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -67,6 +67,7 @@ six==1.11.0
 structlog==18.2.0
 toolz==0.9.0
 traitlets==4.3.2
+treq==20.4.1
 urllib3==1.23
 webargs==5.1.3
 websockets==6.0


### PR DESCRIPTION
This PR fixes [RLP-814](https://jirainfuy.atlassian.net/browse/RLP-814), which is about new exceptions occurring in the test suite.

## Issue
Recent test environments [created from scratch](https://github.com/anarancio/lumino-docs/blob/master/unit-testing/guide.md) are raising new exceptions when running the entire test suite, but old ones aren't.

## Cause
`treq` is a requirement of some dependency in the project, but it is not explicitly defined in `requirements-dev.txt` nor `constraints.txt`. Therefore, `pip` will fetch the latest version of this library when installing dependencies for the testing environment. 

[On September 27th, a new version of `treq` was released](https://pypi.org/project/treq/#history), and so it is automatically installed through `pip` when creating new test environments after that date.

However, this version is incompatible with the test code, and causes it to crash. It might be incompatible with other parts of the code as well, although this hasn't been made apparent yet.

## Solution
Add an entry to the constraints file so that `pip` will fetch the last known version to work with the test code (`20.4.1`) rather than the latest available.