### PR TITLE
RLP-825: rename transport layer fields

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2115,7 +2115,7 @@ class RestAPI:
                 "light_client_display_name": light_client["encrypt_signed_display_name"],
                 "light_client_seed_retry": light_client["encrypt_signed_seed_retry"]
             }
-            light_client_transport = transport_config.transport_layer.new_light_client_transport(
+            light_client_transport = transport_config.transport_layer.new_light_client(
                 address=light_client["address"],
                 config=config,
                 auth_params=auth_params,
@@ -2126,7 +2126,7 @@ class RestAPI:
                 chain_state=views.state_from_raiden(self.raiden_api.raiden)
             )
 
-            self.raiden_api.raiden.transport.add_light_client_transport(light_client_transport)
+            self.raiden_api.raiden.transport.add_light_client(light_client_transport)
 
         return api_response(light_client)
 

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -52,9 +52,9 @@ class MatrixLayer(TransportLayer):
 
             light_clients = storage.get_all_light_clients()
 
-            light_client_transports = []
-            for light_client in light_clients:
+            self._light_clients: List[TransportNode] = []
 
+            for light_client in light_clients:
                 current_server_name = None
 
                 if light_client["current_server_name"]:
@@ -83,10 +83,9 @@ class MatrixLayer(TransportLayer):
                     auth_params,
                 )
 
-                light_client_transports.append(light_client_transport)
+                self._light_clients.append(light_client_transport)
 
             self._full_node: TransportNode = MatrixTransportNode(config["address"], config["transport"]["matrix"])
-            self._light_clients: List[TransportNode] = light_client_transports
 
         except RaidenError as ex:
             click.secho(f"FATAL: {ex}", fg="red")

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -85,27 +85,27 @@ class MatrixLayer(TransportLayer):
 
                 light_client_transports.append(light_client_transport)
 
-            self._hub_transport: TransportNode = MatrixTransportNode(config["address"], config["transport"]["matrix"])
-            self._light_client_transports: List[TransportNode] = light_client_transports
+            self._full_node: TransportNode = MatrixTransportNode(config["address"], config["transport"]["matrix"])
+            self._light_clients: List[TransportNode] = light_client_transports
 
         except RaidenError as ex:
             click.secho(f"FATAL: {ex}", fg="red")
             sys.exit(1)
 
     @property
-    def hub_transport(self) -> TransportNode:
-        return self._hub_transport
+    def full_node(self) -> TransportNode:
+        return self._full_node
 
     @property
-    def light_client_transports(self) -> List[TransportNode]:
-        return self._light_client_transports
+    def light_clients(self) -> List[TransportNode]:
+        return self._light_clients
 
     @staticmethod
-    def new_light_client_transport(address: Address, config: dict, auth_params: dict) -> TransportNode:
+    def new_light_client(address: Address, config: dict, auth_params: dict) -> TransportNode:
         return MatrixLightClientTransportNode(address, config, auth_params)
 
-    def add_light_client_transport(self, light_client_transport: TransportNode):
-        self._light_client_transports.append(light_client_transport)
+    def add_light_client(self, light_client_transport: TransportNode):
+        self._light_clients.append(light_client_transport)
 
-    def remove_light_client_transport(self, light_client_transport: TransportNode):
-        self._light_client_transports.remove(light_client_transport)
+    def remove_light_client(self, light_client_transport: TransportNode):
+        self._light_clients.remove(light_client_transport)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -219,7 +219,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_lockexpired(raiden: "RaidenService", send_lock_expired: SendLockExpired):
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(send_lock_expired.queue_identifier, lock_expired_message)
         )
 
@@ -238,7 +238,7 @@ class RaidenEventHandler(EventHandler):
     ):
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(send_locked_transfer.queue_identifier, mediated_transfer_message)
         )
 
@@ -248,7 +248,7 @@ class RaidenEventHandler(EventHandler):
     ):
         mediated_transfer_message = send_locked_transfer_light.signed_locked_transfer
         light_client_address = to_checksum_address(send_locked_transfer_light.signed_locked_transfer.initiator)
-        for light_client_transport in raiden.transport.light_client_transports:
+        for light_client_transport in raiden.transport.light_clients:
             if light_client_address == light_client_transport.address:
                 light_client_transport.send_message(
                     *TransportMessage.wrap(send_locked_transfer_light.queue_identifier, mediated_transfer_message)
@@ -258,7 +258,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_secretreveal(raiden: "RaidenService", reveal_secret_event: SendSecretReveal):
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(reveal_secret_event.queue_identifier, reveal_secret_message)
         )
 
@@ -275,7 +275,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_balanceproof(raiden: "RaidenService", balance_proof_event: SendBalanceProof):
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(balance_proof_event.queue_identifier, unlock_message)
         )
 
@@ -297,7 +297,7 @@ class RaidenEventHandler(EventHandler):
 
         secret_request_message = message_from_sendevent(secret_request_event)
         raiden.sign(secret_request_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(secret_request_event.queue_identifier, secret_request_message)
         )
 
@@ -318,7 +318,7 @@ class RaidenEventHandler(EventHandler):
     ):
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(refund_transfer_event.queue_identifier, refund_transfer_message)
         )
 
@@ -326,7 +326,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_processed(raiden: "RaidenService", processed_event: SendProcessed):
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
-        raiden.transport.hub_transport.send_message(
+        raiden.transport.full_node.send_message(
             *TransportMessage.wrap(processed_event.queue_identifier, processed_message)
         )
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -487,9 +487,9 @@ class RaidenService(Runnable):
         # - Send pending message
         self.alarm.link_exception(self.on_error)
 
-        self.transport.hub_transport.link_exception(self.on_error)
+        self.transport.full_node.link_exception(self.on_error)
 
-        for light_client_transport in self.transport.light_client_transports:
+        for light_client_transport in self.transport.light_clients:
             light_client_transport.link_exception(self.on_error)
 
         self._start_transport(chain_state)
@@ -528,15 +528,15 @@ class RaidenService(Runnable):
         #
         # We need a timeout to prevent an endless loop from trying to
         # contact the disconnected client
-        self.transport.hub_transport.stop()
+        self.transport.full_node.stop()
 
-        for light_client_transport in self.transport.light_client_transports:
+        for light_client_transport in self.transport.light_clients:
             light_client_transport.stop()
 
         self.alarm.stop()
 
-        self.transport.hub_transport.join()
-        for light_client_transport in self.transport.light_client_transports:
+        self.transport.full_node.join()
+        for light_client_transport in self.transport.light_clients:
             light_client_transport.join()
 
         self.alarm.join()
@@ -597,7 +597,7 @@ class RaidenService(Runnable):
             prev_auth_data = chain_state.last_node_transport_state_authdata.hub_last_transport_authdata,
 
         # Start hub transport
-        self.transport.hub_transport.start(
+        self.transport.full_node.start(
             raiden_service=self,
             message_handler=self.message_handler,
             prev_auth_data=prev_auth_data,
@@ -605,7 +605,7 @@ class RaidenService(Runnable):
 
         # Start lightclient transports
         selected_prev_auth_data = None
-        for light_client_transport in self.transport.light_client_transports:
+        for light_client_transport in self.transport.light_clients:
             if chain_state.last_node_transport_state_authdata is not None:
                 for client_last_transport_authdata in \
                     chain_state.last_node_transport_state_authdata.clients_last_transport_authdata:
@@ -623,7 +623,7 @@ class RaidenService(Runnable):
         self._start_health_check_for_light_client_neighbour(chain_state)
 
     def _start_health_check_for_light_client_neighbour(self, chain_state: ChainState):
-        for light_client in self.transport.light_client_transports:
+        for light_client in self.transport.light_clients:
             for neighbour in views.all_neighbour_nodes(chain_state, light_client.address):
                 self._start_health_check_for_neighbour(neighbour)
 
@@ -764,12 +764,12 @@ class RaidenService(Runnable):
         """
         if self.transport:
             if creator_address is not None:
-                if self.transport.light_client_transports is not None:
-                    for light_client_transport in self.transport.light_client_transports:
+                if self.transport.light_clients is not None:
+                    for light_client_transport in self.transport.light_clients:
                         if to_checksum_address(creator_address) == light_client_transport.address:
                             light_client_transport.start_health_check(node_address)
             else:
-                self.transport.hub_transport.start_health_check(node_address)
+                self.transport.full_node.start_health_check(node_address)
 
     def _callback_new_block(self, latest_block: Dict):
         """Called once a new block is detected by the alarm task.
@@ -967,7 +967,7 @@ class RaidenService(Runnable):
 
     def get_light_client_transport(self, address):
         light_client_transport_result = None
-        for light_client_transport in self.transport.light_client_transports:
+        for light_client_transport in self.transport.light_clients:
             if address == light_client_transport.address:
                 light_client_transport_result = light_client_transport
 
@@ -977,7 +977,7 @@ class RaidenService(Runnable):
         for neighbour in views.all_neighbour_nodes(chain_state):
             if neighbour == ConnectionManager.BOOTSTRAP_ADDR:
                 continue
-            self.transport.hub_transport.whitelist(neighbour)
+            self.transport.full_node.whitelist(neighbour)
 
     def _set_light_clients_transports_whitelist(self, chain_state: ChainState):
         light_clients = self.wal.storage.get_all_light_clients()
@@ -998,14 +998,14 @@ class RaidenService(Runnable):
 
         events_queues = views.get_all_messagequeues(chain_state)
 
-        light_client_transports = self.transport.light_client_transports
+        light_client_transports = self.transport.light_clients
 
         for event_queue in events_queues.values():
             for event in event_queue:
                 if isinstance(event, SendLockedTransfer):
                     transfer = event.transfer
                     if transfer.initiator == self.address:
-                        self.transport.hub_transport.whitelist(address=transfer.target)
+                        self.transport.full_node.whitelist(address=transfer.target)
                 if isinstance(event, SendLockedTransferLight):
                     transfer = event.signed_locked_transfer
                     for light_client_transport in light_client_transports:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -998,8 +998,6 @@ class RaidenService(Runnable):
 
         events_queues = views.get_all_messagequeues(chain_state)
 
-        light_client_transports = self.transport.light_clients
-
         for event_queue in events_queues.values():
             for event in event_queue:
                 if isinstance(event, SendLockedTransfer):
@@ -1008,7 +1006,7 @@ class RaidenService(Runnable):
                         self.transport.full_node.whitelist(address=transfer.target)
                 if isinstance(event, SendLockedTransferLight):
                     transfer = event.signed_locked_transfer
-                    for light_client_transport in light_client_transports:
+                    for light_client_transport in self.transport.light_clients:
                         if transfer.initiator == to_canonical_address(light_client_transport.address):
                             light_client_transport.whitelist(address=transfer.target)
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -466,7 +466,7 @@ def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=
     def fake_receive(room, event):  # pylint: disable=unused-argument
         return True
 
-    with patch.object(app1.raiden.transport.hub_transport, "_handle_message", side_effect=fake_receive):
+    with patch.object(app1.raiden.transport.full_node, "_handle_message", side_effect=fake_receive):
         greenlet = gevent.spawn(
             RaidenAPI(app0.raiden).transfer,
             app0.raiden.default_registry.address,

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -582,8 +582,8 @@ def run_test_clear_closed_queue(raiden_network, token_addresses, network_wait):
         secret=secret,
     )
 
-    app1.raiden.transport.hub_transport.stop()
-    app1.raiden.transport.hub_transport.get()
+    app1.raiden.transport.full_node.stop()
+    app1.raiden.transport.full_node.get()
 
     # make sure to wait until the queue is created
     def has_initiator_events():

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -561,7 +561,7 @@ def run_test_automatic_secret_registration(raiden_chain, token_addresses):
 
     # Stop app0 to avoid sending the unlock, this must be done after the locked
     # transfer is sent.
-    app0.raiden.transport.hub_transport.stop()
+    app0.raiden.transport.full_node.stop()
 
     reveal_secret = RevealSecret(message_identifier=random.randint(0, UINT64_MAX), secret=secret)
     app0.raiden.sign(reveal_secret)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -394,7 +394,7 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
         )
         app0.raiden.handle_and_track_state_change(close_channel)
 
-    app0.raiden.transport.hub_transport._client.add_presence_listener(make_tx)
+    app0.raiden.transport.full_node._client.add_presence_listener(make_tx)
 
     exception = ValueError("exception was not raised from the transport")
     with pytest.raises(InsufficientFunds), gevent.Timeout(200, exception=exception):

--- a/raiden/tests/integration/test_pythonapi_base.py
+++ b/raiden/tests/integration/test_pythonapi_base.py
@@ -467,7 +467,7 @@ def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=
     def fake_receive(room, event):  # pylint: disable=unused-argument
         return True
 
-    with patch.object(app1.raiden.transport.hub_transport, "_handle_message", side_effect=fake_receive):
+    with patch.object(app1.raiden.transport.full_node, "_handle_message", side_effect=fake_receive):
         greenlet = gevent.spawn(
             RaidenAPI(app0.raiden).transfer,
             app0.raiden.default_registry.address,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -122,7 +122,7 @@ def run_test_regression_revealsecret_after_secret(
         host_port = None
         app1.raiden.transport.receive(reveal_data, host_port)
     elif transport_protocol is TransportProtocol.MATRIX:
-        app1.raiden.transport.hub_transport._receive_message(reveal_secret)  # pylint: disable=protected-access
+        app1.raiden.transport.full_node._receive_message(reveal_secret)  # pylint: disable=protected-access
     else:
         raise TypeError("Unknown TransportProtocol")
 
@@ -195,9 +195,9 @@ def run_test_regression_multiple_revealsecret(raiden_network, token_addresses, t
     if transport_protocol is TransportProtocol.UDP:
         message_data = mediated_transfer.encode()
         host_port = None
-        app1.raiden.transport.hub_transport.receive(message_data, host_port)
+        app1.raiden.transport.full_node.receive(message_data, host_port)
     elif transport_protocol is TransportProtocol.MATRIX:
-        app1.raiden.transport.hub_transport._receive_message(mediated_transfer)
+        app1.raiden.transport.full_node._receive_message(mediated_transfer)
     else:
         raise TypeError("Unknown TransportProtocol")
 
@@ -222,11 +222,11 @@ def run_test_regression_multiple_revealsecret(raiden_network, token_addresses, t
     if transport_protocol is TransportProtocol.UDP:
         messages = [unlock.encode(), reveal_secret.encode()]
         host_port = None
-        receive_method = app1.raiden.transport.hub_transport.receive
+        receive_method = app1.raiden.transport.full_node.receive
         wait = set(gevent.spawn_later(0.1, receive_method, data, host_port) for data in messages)
     elif transport_protocol is TransportProtocol.MATRIX:
         messages = [unlock, reveal_secret]
-        receive_method = app1.raiden.transport.hub_transport._receive_message
+        receive_method = app1.raiden.transport.full_node._receive_message
         wait = set(gevent.spawn_later(0.1, receive_method, data) for data in messages)
     else:
         raise TypeError("Unknown TransportProtocol")

--- a/transport/layer.py
+++ b/transport/layer.py
@@ -9,46 +9,47 @@ class Layer(ABC):
     """
     Layer is an abstraction which centralizes all the transport entities for a Lumino node; it is in effect the
     transport layer for the system.
-    It contains the objects pertaining to both the transport logic for the node behaving as a hub, as well as any nodes
-    registered as light clients to be managed.
+    It contains the objects pertaining to both the transport logic for the running node, acting as a full node or a hub,
+    as well as any nodes registered as light clients to be managed.
     """
 
     @abstractmethod
     def __init__(self, config: Dict[str, Any]):
         """
         Initialize the transport layer based on the received configuration in the form of an arbitrary dictionary.
-        This constructor should ultimately set the hub and light client transport nodes in the transport layer.
+        This constructor should ultimately set the transport nodes for the running node and registered light clients
+        in the transport layer.
         """
 
     @property
     @abstractmethod
-    def hub_transport(self) -> TransportNode:
+    def full_node(self) -> TransportNode:
         """
-        Return the transport node corresponding to the running Lumino node, acting as a hub or regular node.
+        Return the transport node corresponding to the running Lumino node, acting as a full node or hub.
         """
 
     @property
     @abstractmethod
-    def light_client_transports(self) -> List[TransportNode]:
+    def light_clients(self) -> List[TransportNode]:
         """
         Return the transport nodes for every light client registered in the running Lumino node.
         """
 
     @staticmethod
     @abstractmethod
-    def new_light_client_transport(address: Address, config: dict, auth_params: dict) -> TransportNode:
+    def new_light_client(address: Address, config: dict, auth_params: dict) -> TransportNode:
         """
         Instantiate a new transport node for a light client to be registered on the transport layer.
         """
 
     @abstractmethod
-    def add_light_client_transport(self, light_client_transport: TransportNode):
+    def add_light_client(self, light_client_transport: TransportNode):
         """
         Add a light client transport node to the layer.
         """
 
     @abstractmethod
-    def remove_light_client_transport(self, light_client_transport: TransportNode):
+    def remove_light_client(self, light_client_transport: TransportNode):
         """
         Remove a light client transport node from the layer.
         """


### PR DESCRIPTION
This PR solves [RLP-825](https://jirainfuy.atlassian.net/browse/RLP-825), which is about renaming transport layer fields that include the term "hub".

## changes
### fields
- `hub_transport` → `full_node`
- `light_client_transports` → `light_clients`
- `_hub_transport` → `_full_node`
- `_light_client_transports` → `_light_clients`
### methods
- `new_light_client_transport` → `new_light_client` 
- `add_light_client_transport` → `add_light_client`
- `remove_light_client_transport` → `remove_light_client`

---

for most of these, they already a field/method for a _transport_ layer class, so it is redundant to include `transport` in the name.