### PR TITLE
RLP-818 Ignoring processed messages for LC

### DIFF
--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -54,15 +54,18 @@ class LightClientMessageHandler:
         )
 
     @classmethod
-    def update_stored_msg_set_signed_data(
+    def update_offchain_light_client_protocol_message_set_signed_message(
         cls, message: Message,
         payment_id: int,
         order: int,
         message_type: LightClientProtocolMessageType,
         wal: WriteAheadLog
     ):
-        return wal.storage.update_light_client_protocol_message_set_signed_data(payment_id, order, message,
-                                                                                str(message_type.value))
+        return wal.storage\
+            .update_offchain_light_client_protocol_message_set_signed_message(payment_id,
+                                                                              order,
+                                                                              message,
+                                                                              str(message_type.value))
 
     @classmethod
     def store_light_client_payment(cls, payment: LightClientPayment, storage: SerializedSQLiteStorage):

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -207,11 +207,12 @@ class RaidenEventHandler(EventHandler):
             stored_but_unsigned = existing_message.signed_message is None
             if stored_but_unsigned and store_message_event.is_signed:
                 # Update messages that were created by the hub and now are received signed by the light client
-                LightClientMessageHandler.update_stored_msg_set_signed_data(store_message_event.message,
-                                                                            store_message_event.payment_id,
-                                                                            store_message_event.message_order,
-                                                                            store_message_event.message_type,
-                                                                            raiden.wal)
+                LightClientMessageHandler\
+                    .update_offchain_light_client_protocol_message_set_signed_message(store_message_event.message,
+                                                                                      store_message_event.payment_id,
+                                                                                      store_message_event.message_order,
+                                                                                      store_message_event.message_type,
+                                                                                      raiden.wal)
             else:
                 log.info("Message for lc already received, ignoring db storage")
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,6 @@ from eth_utils import to_checksum_address
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.lightclient.models.client_model import ClientType
-from raiden.messages import Message
 from raiden.storage.serialize import SerializationBase
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import get_system_spec
@@ -1490,7 +1489,7 @@ class SerializedSQLiteStorage(SQLiteStorage):
 
     def update_light_client_protocol_message_with_signed_message(self,
                                                                  internal_msg_identifier: int,
-                                                                 signed_message: Message):
+                                                                 signed_message: "Message"):
         return self.update(
             """
                 UPDATE light_client_protocol_message


### PR DESCRIPTION
In this PR we are:

* Adding query condition to the long polling to get only the not processed messages by the LC for the specific types ('SettlementRequired', 'RequestRegisterSecret', 'UnlockLightRequest').
* Adding a new aux method for sql updates, we are repeating the code all over the place, i just extracted that code to an aux method to call that instead
* Adding a new method to update a protocol message by internal id

This affects the SDK Long Polling