### PR TITLE
Bug fix/rlp 762/payments not working after refund

### DIFF
--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -73,8 +73,8 @@ class LightClientMessageHandler:
     def update_light_client_payment_status(cls, payment_id: int, status: LightClientPaymentStatus,
                                            storage: SerializedSQLiteStorage):
         exists_payment = storage.get_light_client_payment(payment_id)
-        if not exists_payment:
-            storage.update_light_client_payment_status(payment_id, status, storage)
+        if exists_payment:
+            storage.update_light_client_payment_status(payment_id, status)
 
     @classmethod
     def is_light_client_protocol_message_already_stored(cls, payment_id: int,

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -73,8 +73,7 @@ class LightClientMessageHandler:
     @classmethod
     def update_light_client_payment_status(cls, payment_id: int, status: LightClientPaymentStatus,
                                            storage: SerializedSQLiteStorage):
-        exists_payment = storage.get_light_client_payment(payment_id)
-        if exists_payment:
+        if storage.get_light_client_payment(payment_id):
             storage.update_light_client_payment_status(payment_id, status)
 
     @classmethod

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -92,15 +92,19 @@ class LightClientMessageHandler:
             storage.update_light_client_payment_status(payment_id, status)
 
     @classmethod
-    def is_light_client_protocol_message_already_stored(cls, payment_id: int,
+    def is_light_client_protocol_message_already_stored(cls,
+                                                        payment_id: int,
                                                         order: int,
                                                         message_type: LightClientProtocolMessageType,
                                                         message_protocol_type: str,
-                                                        wal: WriteAheadLog
-                                                        ):
-        existing_message = wal.storage.is_light_client_protocol_message_already_stored(payment_id, order,
-                                                                                       str(message_type.value),
-                                                                                       message_protocol_type)
+                                                        light_client_address: AddressHex,
+                                                        wal: WriteAheadLog):
+        existing_message = \
+            wal.storage.is_light_client_protocol_message_already_stored(payment_id=payment_id,
+                                                                        order=order,
+                                                                        message_type=str(message_type.value),
+                                                                        message_protocol_type=message_protocol_type,
+                                                                        light_client_address=light_client_address)
 
         if existing_message:
             return LightClientProtocolMessage(existing_message[5] is not None,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -174,7 +174,6 @@ class MessageHandler:
                     secret=random_secret(),
                     refund_transfer=message
                 )
-                print("raiden/message_handler.py:184 >>>> Triggering ActionTransferRerouteLight")
                 raiden.handle_and_track_state_change(state_change)
             else:
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -26,8 +26,12 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
     ReceiveTransferRefund,
     ActionTransferReroute,
-    ReceiveSecretRequestLight, ReceiveSecretRevealLight, ReceiveTransferCancelRoute, ReceiveLockExpiredLight,
-    StoreRefundTransferLight, ActionTransferRerouteLight)
+    ReceiveSecretRequestLight,
+    ReceiveSecretRevealLight,
+    ReceiveTransferCancelRoute,
+    ReceiveLockExpiredLight,
+    ActionTransferRerouteLight
+)
 from raiden.transfer.state import balanceproof_from_envelope
 from raiden.transfer.state_change import ReceiveDelivered, ReceiveProcessed, ReceiveUnlock, ReceiveUnlockLight
 from raiden.utils import pex, random_secret
@@ -164,24 +168,24 @@ class MessageHandler:
             )
             raiden.handle_and_track_state_change(state_change)
 
-            # Currently, the only case where we can be initiators and not
-            # know the secret is if the transfer is part of an atomic swap. In
-            # the case of an atomic swap, we will not try to re-route the
-            # transfer. In all other cases we can try to find another route
-            # (and generate a new secret)
-            old_secret = views.get_transfer_secret(chain_state, from_transfer.lock.secrethash)
-            is_secret_known = old_secret is not None and old_secret != EMPTY_SECRET
-
             if is_light_client:
-                if is_secret_known:
-                    state_change = ActionTransferRerouteLight(
-                        transfer=from_transfer,
-                        secret=random_secret(),
-                        refund_transfer=message
-                    )
-                    print("raiden/message_handler.py:184 >>>> Triggering ActionTransferRerouteLight")
-                    raiden.handle_and_track_state_change(state_change)
+                state_change = ActionTransferRerouteLight(
+                    transfer=from_transfer,
+                    secret=random_secret(),
+                    refund_transfer=message
+                )
+                print("raiden/message_handler.py:184 >>>> Triggering ActionTransferRerouteLight")
+                raiden.handle_and_track_state_change(state_change)
             else:
+
+                # Currently, the only case where we can be initiators and not
+                # know the secret is if the transfer is part of an atomic swap. In
+                # the case of an atomic swap, we will not try to re-route the
+                # transfer. In all other cases we can try to find another route
+                # (and generate a new secret)
+                old_secret = views.get_transfer_secret(chain_state, from_transfer.lock.secrethash)
+                is_secret_known = old_secret is not None and old_secret != EMPTY_SECRET
+
                 if is_secret_known:
                     state_change = ActionTransferReroute(
                         transfer=from_transfer,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -171,7 +171,6 @@ class MessageHandler:
             if is_light_client:
                 state_change = ActionTransferRerouteLight(
                     transfer=from_transfer,
-                    secret=random_secret(),
                     refund_transfer=message
                 )
                 raiden.handle_and_track_state_change(state_change)

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1720,7 +1720,7 @@ class MatrixLightClientTransport(MatrixTransport):
         self._raiden_service.on_message(delivered, True)
 
     def _receive_message_to_lc(self, message: Union[SignedRetrieableMessage, Processed]):
-        print("<<---- Matrix Received Message LC transport" + str(message))
+        print("<<---- Matrix Received Message LC transport {}".format(message.to_dict() if message else str(message)))
         assert self._raiden_service is not None
         self.log.debug(
             "Message received",

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -188,11 +188,13 @@ class RaidenEventHandler(EventHandler):
 
     @staticmethod
     def handle_store_message(raiden: "RaidenService", store_message_event: StoreMessageEvent):
-        existing_message = LightClientMessageHandler.is_message_already_stored(
-            store_message_event.light_client_address,
-            store_message_event.message_type,
-            store_message_event.message,
-            raiden.wal)
+        existing_message = LightClientMessageHandler.is_light_client_protocol_message_already_stored(
+            payment_id=store_message_event.payment_id,
+            order=store_message_event.message_order,
+            message_type=store_message_event.message_type,
+            message_protocol_type=store_message_event.message.to_dict()["type"],
+            light_client_address=store_message_event.light_client_address,
+            wal=raiden.wal)
         if not existing_message:
             LightClientMessageHandler.store_light_client_protocol_message(store_message_event.message_id,
                                                                           store_message_event.message,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -188,11 +188,10 @@ class RaidenEventHandler(EventHandler):
 
     @staticmethod
     def handle_store_message(raiden: "RaidenService", store_message_event: StoreMessageEvent):
-        existing_message = LightClientMessageHandler.is_light_client_protocol_message_already_stored(
-            store_message_event.payment_id,
-            store_message_event.message_order,
+        existing_message = LightClientMessageHandler.is_message_already_stored(
+            store_message_event.light_client_address,
             store_message_event.message_type,
-            store_message_event.message.to_dict()["type"],
+            store_message_event.message,
             raiden.wal)
         if not existing_message:
             LightClientMessageHandler.store_light_client_protocol_message(store_message_event.message_id,
@@ -204,8 +203,7 @@ class RaidenEventHandler(EventHandler):
                                                                           raiden.wal,
                                                                           store_message_event.payment_id)
         else:
-            stored_but_unsigned = existing_message.signed_message is None
-            if stored_but_unsigned and store_message_event.is_signed:
+            if not existing_message.signed_message and store_message_event.is_signed:
                 # Update messages that were created by the hub and now are received signed by the light client
                 LightClientMessageHandler.update_stored_msg_set_signed_data(store_message_event.message,
                                                                             store_message_event.payment_id,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -225,8 +225,13 @@ class SQLiteStorage:
 
         return cursor.fetchone()
 
-    def is_light_client_protocol_message_already_stored(self, payment_id: int, order: int,
-                                                        message_type: str, message_protocol_type:str):
+    def is_light_client_protocol_message_already_stored(self,
+                                                        payment_id: int,
+                                                        order: int,
+                                                        message_type: str,
+                                                        message_protocol_type: str,
+                                                        light_client_address: "AddressHex"):
+
         cursor = self.conn.cursor()
         cursor.execute(
             """
@@ -236,9 +241,14 @@ class SQLiteStorage:
                 AND json_extract(light_client_protocol_message.unsigned_message, '$.type') == ?
                 OR json_extract(light_client_protocol_message.signed_message, '$') is not NULL
                 AND json_extract(light_client_protocol_message.signed_message, '$.type') == ?)
-
+                AND light_client_address = ?
             """,
-            (str(payment_id), order, message_type,message_protocol_type,message_protocol_type)
+            (str(payment_id),
+             order,
+             message_type,
+             message_protocol_type,
+             message_protocol_type,
+             to_checksum_address(light_client_address))
         )
 
         return cursor.fetchone()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -179,7 +179,8 @@ class SQLiteStorage:
     def update_light_client_payment_status(self, light_client_payment_id, status):
         with self.write_lock, self.conn:
             cursor = self.conn.execute(
-                "UPDATE light_client_payment SET payment_status =? WHERE payment_id=?", (str(status.value), light_client_payment_id)
+                "UPDATE light_client_payment SET payment_status = ? WHERE payment_id = ?",
+                (str(status.value), str(light_client_payment_id))
             )
             last_id = cursor.lastrowid
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1733,7 +1733,12 @@ def handle_receive_lock_expired_light(
             LightClientProtocolMessageType.PaymentExpired,
             state_change.lock_expired.recipient
         )
-        events = [store_lock_expired]
+        send_processed = SendProcessed(
+            recipient=state_change.balance_proof.sender,
+            channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
+            message_identifier=state_change.message_identifier,
+        )
+        events = [store_lock_expired, send_processed]
     else:
         assert msg, "is_valid_lock_expired should return error msg if not valid"
         invalid_lock_expired = EventInvalidReceivedLockExpired(
@@ -1807,9 +1812,12 @@ def handle_receive_lockedtransfer_light(
 
         lock = mediated_transfer.lock
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock
-        events = []
-
-
+        send_processed = SendProcessed(
+            recipient=mediated_transfer.balance_proof.sender,
+            channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
+            message_identifier=mediated_transfer.message_identifier,
+        )
+        events = [send_processed]
     else:
         assert msg, "is_valid_lock_expired should return error msg if not valid"
         invalid_locked = EventInvalidReceivedLockedTransfer(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -559,16 +559,11 @@ def valid_lockedtransfer_check(
     distributable = get_distributable(sender_state, receiver_state)
     expected_locked_amount = current_locked_amount + lock.amount
 
-    print("sender_state = {}".format(sender_state.balance_proof))
-    print("receiver_state = {}".format(receiver_state.balance_proof))
-
     is_balance_proof_usable, invalid_balance_proof_msg = is_balance_proof_usable_onchain(
         received_balance_proof=received_balance_proof,
         channel_state=channel_state,
         sender_state=sender_state,
     )
-
-    print("IS BALANCE PROOF USABLE ?????????????????????????????? {} {}".format(is_balance_proof_usable, invalid_balance_proof_msg))
 
     result: MerkletreeOrError = (False, None, None, None)
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1803,6 +1803,8 @@ def handle_receive_lockedtransfer_light(
         channel_state.partner_state.balance_proof = mediated_transfer.balance_proof
         channel_state.partner_state.merkletree = merkletree
 
+        print("raiden/transfer/channel.py:1806 PARTNER STATE UPDATED WITH BP {}".format(channel_state.partner_state.balance_proof))
+
         lock = mediated_transfer.lock
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock
         events = []

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1453,20 +1453,7 @@ def events_for_expired_lock(
         channel_state.our_state.merkletree = merkletree
         channel_state.our_state.balance_proof = send_lock_expired.balance_proof
 
-        print("HANDLING EXPIRED LOCK FROM BLOCK CHANGE, OUR BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(channel_state.our_state.balance_proof.nonce))
-        print("OUR PARTNER BALANCE PROOF HAS NONCE = {}".format(
-            channel_state.partner_state.balance_proof.nonce if channel_state.partner_state.balance_proof else "NO BALANCE PROOF"))
-
-        # we only delete the lock when we know that the balance proof with the nonce was updated on both sides
-        if channel_state.partner_state.balance_proof \
-           and channel_state.partner_state.balance_proof.nonce == channel_state.our_state.balance_proof.nonce:
-            # this means we already received the lock expired message with the updated nonce
-            # so we can delete this to trigger the payment task deletion
-            # otherwise the partner needs to send us the lock expired with
-            # the updated nonce before we can delete the payment task
-            _del_unclaimed_lock(channel_state.our_state, locked_lock.secrethash)
-            _del_unclaimed_lock(channel_state.partner_state, locked_lock.secrethash)
-            print("DELETED LOCK BECAUSE WE ALREADY RECEIVED A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE SENDING OUT THE LOCK EXPIRED")
+        _del_unclaimed_lock(channel_state.our_state, locked_lock.secrethash)
 
         if channel_state.is_light_channel:
             # Store the send lock expired light message
@@ -1629,7 +1616,9 @@ def handle_refundtransfer(
 
 
 def handle_receive_lock_expired(
-    channel_state: NettingChannelState, state_change: ReceiveLockExpired, block_number: BlockNumber
+    channel_state: NettingChannelState,
+    state_change: ReceiveLockExpired,
+    block_number: BlockNumber
 ) -> TransitionResult[NettingChannelState]:
     """Remove expired locks from channel states."""
     is_valid, msg, merkletree = is_valid_lock_expired(
@@ -1646,26 +1635,7 @@ def handle_receive_lock_expired(
         channel_state.partner_state.balance_proof = state_change.balance_proof
         channel_state.partner_state.merkletree = merkletree
 
-        if channel_state.canonical_identifier.channel_identifier == 8:
-            print("STATE CHANGE ReceiveLockExpired BALANCE PROOF {}".format(state_change.balance_proof))
-
-            print("HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
-                channel_state.partner_state.balance_proof.nonce))
-            print("OUR BALANCE PROOF HAS NONCE = {}".format(
-                channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
-
-        # we only delete the lock when we know that the balance proof with the nonce was updated on both sides
-        if channel_state.our_state.balance_proof \
-           and channel_state.our_state.balance_proof.nonce == channel_state.partner_state.balance_proof.nonce:
-            # this means we already sent the lock expired message with the updated nonce
-            # so we can delete this to trigger the payment task deletion
-            # otherwise we needs to send the lock expired with
-            # the updated nonce before we can delete the payment task
-            _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
-            _del_unclaimed_lock(channel_state.our_state, state_change.secrethash)
-            if channel_state.canonical_identifier.channel_identifier == 8:
-                print(
-                    "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
+        _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
 
         send_processed = SendProcessed(
             recipient=state_change.balance_proof.sender,
@@ -1702,42 +1672,24 @@ def handle_receive_lock_expired_light(
         channel_state.partner_state.balance_proof = state_change.balance_proof
         channel_state.partner_state.merkletree = merkletree
 
-        if channel_state.canonical_identifier.channel_identifier == 8:
-            print("STATE CHANGE ReceiveLockExpiredLight BALANCE PROOF {}".format(state_change.balance_proof))
-
-            print(
-                "HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED LIGHT, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
-                    channel_state.partner_state.balance_proof.nonce))
-            print("OUR BALANCE PROOF HAS NONCE = {}".format(
-                channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
-
-        # we only delete the lock when we know that the balance proof with the nonce was updated on both sides
-        if channel_state.our_state.balance_proof \
-           and channel_state.our_state.balance_proof.nonce == channel_state.partner_state.balance_proof.nonce:
-            # this means we already sent the lock expired message with the updated nonce
-            # so we can delete this to trigger the payment task deletion
-            # otherwise we needs to send the lock expired with
-            # the updated nonce before we can delete the payment task
-            _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
-            _del_unclaimed_lock(channel_state.our_state, state_change.secrethash)
-            if channel_state.canonical_identifier.channel_identifier == 8:
-                print(
-                    "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
+        _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
 
         store_lock_expired = StoreMessageEvent(
             state_change.lock_expired.message_identifier,
             payment_id,
             1,
             state_change.lock_expired,
-            True,
+            False,
             LightClientProtocolMessageType.PaymentExpired,
             state_change.lock_expired.recipient
         )
+
         send_processed = SendProcessed(
             recipient=state_change.balance_proof.sender,
             channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
             message_identifier=state_change.message_identifier,
         )
+
         events = [store_lock_expired, send_processed]
     else:
         assert msg, "is_valid_lock_expired should return error msg if not valid"
@@ -1880,11 +1832,6 @@ def handle_block(
     assert state_change.block_number == block_number
 
     events: List[Event] = list()
-
-    if channel_state.canonical_identifier.channel_identifier == 8:
-        print("HANDLE BLOCK FOR CHANNEL ID {} WITH PARTNER {}".format(channel_state.canonical_identifier.channel_identifier, channel_state.partner_state.address.hex()))
-        print("PARTNER BALANCE PROOF = {}".format(channel_state.partner_state.balance_proof))
-        print("OUR BALANCE PROOF = {}".format(channel_state.our_state.balance_proof))
 
     if get_status(channel_state) == CHANNEL_STATE_CLOSED:
         msg = "channel get_status is STATE_CLOSED, but close_transaction is not set"

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1639,16 +1639,19 @@ def handle_receive_lock_expired(
         block_number=block_number,
     )
 
-    events: List[Event] = list()
+    events: List[Event]
     if is_valid:
         assert merkletree, "is_valid_lock_expired should return merkletree if valid"
         channel_state.partner_state.balance_proof = state_change.balance_proof
         channel_state.partner_state.merkletree = merkletree
 
-        print("HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
-            channel_state.partner_state.balance_proof.nonce))
-        print("OUR BALANCE PROOF HAS NONCE = {}".format(
-            channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
+        if channel_state.canonical_identifier.channel_identifier == 8:
+            print("STATE CHANGE ReceiveLockExpired BALANCE PROOF {}".format(state_change.balance_proof))
+
+            print("HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
+                channel_state.partner_state.balance_proof.nonce))
+            print("OUR BALANCE PROOF HAS NONCE = {}".format(
+                channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
 
         # we only delete the lock when we know that the balance proof with the nonce was updated on both sides
         if channel_state.our_state.balance_proof \
@@ -1659,8 +1662,9 @@ def handle_receive_lock_expired(
             # the updated nonce before we can delete the payment task
             _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
             _del_unclaimed_lock(channel_state.our_state, state_change.secrethash)
-            print(
-                "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
+            if channel_state.canonical_identifier.channel_identifier == 8:
+                print(
+                    "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
 
         send_processed = SendProcessed(
             recipient=state_change.balance_proof.sender,
@@ -1690,18 +1694,21 @@ def handle_receive_lock_expired_light(
         block_number=block_number,
     )
 
-    events: List[Event] = list()
+    events: List[Event]
     if is_valid:
         assert merkletree, "is_valid_lock_expired should return merkletree if valid"
 
         channel_state.partner_state.balance_proof = state_change.balance_proof
         channel_state.partner_state.merkletree = merkletree
 
-        print(
-            "HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED LIGHT, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
-                channel_state.partner_state.balance_proof.nonce))
-        print("OUR BALANCE PROOF HAS NONCE = {}".format(
-            channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
+        if channel_state.canonical_identifier.channel_identifier == 8:
+            print("STATE CHANGE ReceiveLockExpiredLight BALANCE PROOF {}".format(state_change.balance_proof))
+
+            print(
+                "HANDLING EXPIRED LOCK FROM RECEIVE LOCK EXPIRED LIGHT, PARTNER BALANCE PROOF WAS UPDATED WITH NONCE = {}".format(
+                    channel_state.partner_state.balance_proof.nonce))
+            print("OUR BALANCE PROOF HAS NONCE = {}".format(
+                channel_state.our_state.balance_proof.nonce if channel_state.our_state.balance_proof else "NO BALANCE PROOF"))
 
         # we only delete the lock when we know that the balance proof with the nonce was updated on both sides
         if channel_state.our_state.balance_proof \
@@ -1712,8 +1719,9 @@ def handle_receive_lock_expired_light(
             # the updated nonce before we can delete the payment task
             _del_unclaimed_lock(channel_state.partner_state, state_change.secrethash)
             _del_unclaimed_lock(channel_state.our_state, state_change.secrethash)
-            print(
-                "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
+            if channel_state.canonical_identifier.channel_identifier == 8:
+                print(
+                    "DELETED LOCK BECAUSE WE ALREADY SENT A LOCK EXPIRED SO WE CAN DELETE IT SINCE WE ARE RECEIVING THE LOCK EXPIRED FROM THE PARTNER")
 
         store_lock_expired = StoreMessageEvent(
             state_change.lock_expired.message_identifier,
@@ -1862,8 +1870,10 @@ def handle_block(
 
     events: List[Event] = list()
 
-    print("HANDLE BLOCK FOR CHANNEL ID {} WITH PARTNER {}".format(channel_state.canonical_identifier.channel_identifier, channel_state.partner_state.address.hex()))
-    print("PARTNER BALANCE PROOF = {}".format(channel_state.partner_state.balance_proof))
+    if channel_state.canonical_identifier.channel_identifier == 8:
+        print("HANDLE BLOCK FOR CHANNEL ID {} WITH PARTNER {}".format(channel_state.canonical_identifier.channel_identifier, channel_state.partner_state.address.hex()))
+        print("PARTNER BALANCE PROOF = {}".format(channel_state.partner_state.balance_proof))
+        print("OUR BALANCE PROOF = {}".format(channel_state.our_state.balance_proof))
 
     if get_status(channel_state) == CHANNEL_STATE_CLOSED:
         msg = "channel get_status is STATE_CLOSED, but close_transaction is not set"

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1679,13 +1679,7 @@ def handle_receive_lock_expired_light(
             state_change.lock_expired.recipient
         )
 
-        send_processed = SendProcessed(
-            recipient=state_change.balance_proof.sender,
-            channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
-            message_identifier=state_change.message_identifier,
-        )
-
-        events = [store_lock_expired, send_processed]
+        events = [store_lock_expired]
     else:
         assert msg, "is_valid_lock_expired should return error msg if not valid"
         invalid_lock_expired = EventInvalidReceivedLockExpired(
@@ -1745,7 +1739,7 @@ def handle_receive_lockedtransfer_light(
     transfer. The receiver needs to ensure that the merkle root has the
     secrethash included, otherwise it won't be able to claim it.
     """
-    events: List[Event]
+    events: List[Event] = []
     is_valid, msg, merkletree, handle_invoice_result = is_valid_lockedtransfer(
         mediated_transfer, channel_state, channel_state.partner_state, channel_state.our_state, storage
     )
@@ -1757,12 +1751,6 @@ def handle_receive_lockedtransfer_light(
 
         lock = mediated_transfer.lock
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock
-        send_processed = SendProcessed(
-            recipient=mediated_transfer.balance_proof.sender,
-            channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
-            message_identifier=mediated_transfer.message_identifier,
-        )
-        events = [send_processed]
     else:
         assert msg, "is_valid_lock_expired should return error msg if not valid"
         invalid_locked = EventInvalidReceivedLockedTransfer(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1674,7 +1674,7 @@ def handle_receive_lock_expired_light(
             payment_id,
             1,
             state_change.lock_expired,
-            False,
+            True,
             LightClientProtocolMessageType.PaymentExpired,
             state_change.lock_expired.recipient
         )
@@ -1754,8 +1754,6 @@ def handle_receive_lockedtransfer_light(
         assert merkletree, "is_valid_lock_expired should return merkletree if valid"
         channel_state.partner_state.balance_proof = mediated_transfer.balance_proof
         channel_state.partner_state.merkletree = merkletree
-
-        print("raiden/transfer/channel.py:1806 PARTNER STATE UPDATED WITH BP {}".format(channel_state.partner_state.balance_proof))
 
         lock = mediated_transfer.lock
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -121,9 +121,6 @@ def handle_block(
         else:
             # if lock is not in our or our partner's locked locks then the
             # task can go
-            print(
-                "TRIGGERING TRANSITION RESULT WITH NONE CAUSING PAYMENT TASK WITH SECRET HASH = {} TO BE DELETED".format(
-                    secrethash.hex()))
             return TransitionResult(None, list())
 
     lock_expiration_threshold = BlockNumber(
@@ -178,9 +175,6 @@ def handle_block(
             channel_state=channel_state, secrethash=secrethash
         )
         initiator_state.transfer_state = "transfer_expired"
-
-        if not lock_exists:
-            print("TRIGGERING TRANSITION RESULT WITH NONE CAUSING PAYMENT TASK WITH SECRET HASH = {} TO BE DELETED".format(secrethash.hex()))
 
         return TransitionResult(
             # If the lock is either in our state or partner state we keep the

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -121,6 +121,9 @@ def handle_block(
         else:
             # if lock is not in our or our partner's locked locks then the
             # task can go
+            print(
+                "TRIGGERING TRANSITION RESULT WITH NONE CAUSING PAYMENT TASK WITH SECRET HASH = {} TO BE DELETED".format(
+                    secrethash.hex()))
             return TransitionResult(None, list())
 
     lock_expiration_threshold = BlockNumber(
@@ -175,6 +178,9 @@ def handle_block(
             channel_state=channel_state, secrethash=secrethash
         )
         initiator_state.transfer_state = "transfer_expired"
+
+        if not lock_exists:
+            print("TRIGGERING TRANSITION RESULT WITH NONE CAUSING PAYMENT TASK WITH SECRET HASH = {} TO BE DELETED".format(secrethash.hex()))
 
         return TransitionResult(
             # If the lock is either in our state or partner state we keep the

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -7,7 +7,6 @@ from raiden.lightclient.handlers.light_client_message_handler import LightClient
 from raiden.lightclient.models.light_client_payment import LightClientPaymentStatus
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
 
-from raiden.messages import RefundTransfer
 from raiden.storage.sqlite import SerializedSQLiteStorage
 
 from raiden.transfer import channel, routes

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -397,8 +397,6 @@ def handle_transfer_reroute_light(
     storage: SerializedSQLiteStorage
 ) -> TransitionResult[InitiatorPaymentState]:
 
-    print("raiden/transfer/mediated_transfer/initiator_manager.py:396 running handle_transfer_reroute_light")
-
     refund_transfer = state_change.refund_transfer
 
     if not refund_transfer:
@@ -798,8 +796,7 @@ def state_transition(
         )
     elif type(state_change) == ActionTransferRerouteLight:
         assert isinstance(state_change, ActionTransferRerouteLight), MYPY_ANNOTATION
-        msg = "ActionTransferRerouteLight should be accompanied by a valid payment state"
-        assert payment_state, msg
+        assert payment_state, "ActionTransferRerouteLight should be accompanied by a valid payment state"
         iteration = handle_transfer_reroute_light(
             payment_state=payment_state,
             state_change=state_change,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -403,13 +403,13 @@ def handle_transfer_reroute_light(
         raise RaidenUnrecoverableError("Refund Transfer not found, state has changed with action "
                                        "ActionTransferRerouteLight but refund_transfer param was not set")
 
-    store_refund_transfer = StoreMessageEvent(refund_transfer.message_identifier,
-                                              refund_transfer.payment_identifier,
-                                              1,
-                                              refund_transfer,
-                                              True,
-                                              LightClientProtocolMessageType.PaymentRefund,
-                                              refund_transfer.recipient)
+    store_refund_transfer = StoreMessageEvent(message_id=refund_transfer.message_identifier,
+                                              payment_id=refund_transfer.payment_identifier,
+                                              message_order=1,
+                                              message=refund_transfer,
+                                              is_signed=True,
+                                              message_type=LightClientProtocolMessageType.PaymentRefund,
+                                              light_client_address=refund_transfer.recipient)
 
     try:
         initiator_state = payment_state.initiator_transfers.get(state_change.transfer.lock.secrethash)

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -167,9 +167,6 @@ def subdispatch_to_initiatortransfer(
 
     if sub_iteration.new_state is None:
         print("No new state, payment task for initiator ends")
-        print("DELETED TASK FOR PAYMENT WITH SECRETHASH = {}".format(initiator_state.transfer.lock.secrethash))
-        print("TASK = {}".format(payment_state.initiator_transfers[initiator_state.transfer.lock.secrethash].to_dict()))
-        print("STATE CHANGE = {}".format(state_change))
         del payment_state.initiator_transfers[initiator_state.transfer.lock.secrethash]
 
     return sub_iteration

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -30,8 +30,14 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretRequest,
     ReceiveSecretReveal,
     ActionTransferReroute,
-    ActionInitInitiatorLight, ReceiveSecretRequestLight, ActionSendSecretRevealLight, ReceiveSecretRevealLight,
-    ReceiveTransferCancelRoute, StoreRefundTransferLight, ReceiveLockExpiredLight, ActionTransferRerouteLight)
+    ActionInitInitiatorLight,
+    ReceiveSecretRequestLight,
+    ActionSendSecretRevealLight,
+    ReceiveSecretRevealLight,
+    ReceiveTransferCancelRoute,
+    ReceiveLockExpiredLight,
+    ActionTransferRerouteLight
+)
 from raiden.transfer.state import RouteState
 from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal
 from raiden.utils.typing import (

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -666,13 +666,14 @@ class ActionTransferReroute(BalanceProofStateChange):
         return instance
 
 
-class ActionTransferRerouteLight(ActionTransferReroute):
+class ActionTransferRerouteLight(BalanceProofStateChange):
     def __init__(
-        self, transfer: LockedTransferSignedState, secret: Secret, refund_transfer: RefundTransfer
+        self, transfer: LockedTransferSignedState, refund_transfer: RefundTransfer
     ) -> None:
-        super().__init__(transfer, secret)
+        super().__init__(transfer.balance_proof)
         if not isinstance(refund_transfer, RefundTransfer):
             raise ValueError("refund_transfer must be an RefundTransfer instance.")
+        self.transfer = transfer
         self.refund_transfer = refund_transfer
 
     def __repr__(self) -> str:
@@ -698,7 +699,6 @@ class ActionTransferRerouteLight(ActionTransferReroute):
     def from_dict(cls, data: Dict[str, Any]) -> "ActionTransferRerouteLight":
         instance = cls(
             transfer=data["transfer"],
-            secret=Secret(deserialize_bytes(data["secret"])),
             refund_transfer=data["refund_transfer"]
         )
         return instance

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -691,15 +691,16 @@ class ActionTransferRerouteLight(BalanceProofStateChange):
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        super_dict: Dict[str, Any] = super().to_dict()
-        super_dict["refund_transfer"] = self.refund_transfer
-        return super_dict
+        return {
+            "transfer": self.transfer.to_dict(),
+            "refund_transfer": self.refund_transfer.to_dict()
+        }
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ActionTransferRerouteLight":
         instance = cls(
-            transfer=data["transfer"],
-            refund_transfer=data["refund_transfer"]
+            transfer=LockedTransferSignedState.from_dict(data["transfer"]),
+            refund_transfer=RefundTransfer.from_dict(data["refund_transfer"])
         )
         return instance
 

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -851,15 +851,7 @@ def handle_receive_transfer_refund_cancel_route(
 def handle_receive_transfer_refund_cancel_route_light(
     chain_state: ChainState, state_change: ActionTransferRerouteLight, storage
 ) -> TransitionResult[ChainState]:
-
-    new_secrethash = state_change.secrethash
-    current_payment_task = chain_state.payment_mapping.secrethashes_to_task[
-        state_change.transfer.lock.secrethash
-    ]
-    chain_state.payment_mapping.secrethashes_to_task.update(
-        {new_secrethash: copy.deepcopy(current_payment_task)}
-    )
-    return subdispatch_to_paymenttask(chain_state, state_change, new_secrethash, storage)
+    return subdispatch_to_paymenttask(chain_state, state_change, state_change.transfer.lock.secrethash, storage)
 
 
 def handle_receive_transfer_cancel_route(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -35,10 +35,18 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
     ReceiveTransferRefund,
     ActionTransferReroute,
-    ActionInitInitiatorLight, ReceiveSecretRequestLight, ActionSendSecretRevealLight, ReceiveSecretRevealLight,
-    ActionSendUnlockLight, ActionInitTargetLight, ActionSendSecretRequestLight, ActionSendLockExpiredLight,
-    ReceiveLockExpiredLight, ReceiveTransferCancelRoute,
-    StoreRefundTransferLight, ActionTransferRerouteLight)
+    ActionInitInitiatorLight,
+    ReceiveSecretRequestLight,
+    ActionSendSecretRevealLight,
+    ReceiveSecretRevealLight,
+    ActionSendUnlockLight,
+    ActionInitTargetLight,
+    ActionSendSecretRequestLight,
+    ActionSendLockExpiredLight,
+    ReceiveLockExpiredLight,
+    ReceiveTransferCancelRoute,
+    ActionTransferRerouteLight
+)
 from raiden.transfer.state import (
     ChainState,
     InitiatorTask,


### PR DESCRIPTION
This PR attempts to fix the bug described on https://jirainfuy.atlassian.net/browse/RLP-762

This comes from the old PR https://github.com/rsksmart/lumino/pull/125

## Scenario

![imagen](https://user-images.githubusercontent.com/7540348/95608208-2e388d00-0a33-11eb-9af7-61cb755a93bc.png)

* Satoshi sent out a mediated payment to Andreas through the available channels of 0.3 tokens
* The first channel used is Satoshi -> Sergio that fails since Sergio doesn't have enough balance to transfer to Andreas
* The second channel used is Satoshi -> Vitalik that fails for the same reason
* The last channel used is Satoshi -> Isabel that succeed since it has enough balance
* Then when the mediated payment was successfully transferred we have 2 expirations (LockExpired) to wait for the failed payments through Sergio and Vitalik
* We try to send a payment from Sergio (or Vitalik) to Satoshi and the payment fails, we can't send any payments from those participants to Satoshi anymore from this point

## Error found

We discover through testing and debugging that the error is only when the node is in Hub Mode, this means that Satoshi must be a LC. Only in that case the error is happening, for full nodes this works just fine.
We see that the root cause of the error is a missing part of the code to handle a RefundTransfer when we are LightClients. So basically if you receive a RefundTransfer and the node is in Hub Mode the handle of that transfer is not working as it should and it doesn't updates the partner state correctly. Later because of that the partner state is unsync and we have a nonce error when we receive any payment on that channel.

## Possible Solution

A solution could be to add the missing handling logic for RefundTransfer when we are in Hub Mode and add other controls to keep the partner state up to date. Doing that the nonce never get's unsync but we have other issues comming from that, basically the LC doesn't send the processed messages correctly and also the lock expired is not being sent to the partner.

This affects the Payment flow for mediated payments