### PR TITLE
RLP-715/Possible fix LC-FN-LC Pay

### DIFF
--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -81,13 +81,13 @@ class LightClientMessageHandler:
             storage.update_light_client_payment_status(payment_id, status, storage)
 
     @classmethod
-    def is_light_client_protocol_message_already_stored(cls, payment_id: int,
+    def is_light_client_protocol_message_already_stored(cls, message_id: int, payment_id: int,
                                                         order: int,
                                                         message_type: LightClientProtocolMessageType,
                                                         message_protocol_type: str,
                                                         wal: WriteAheadLog
                                                         ):
-        existing_message = wal.storage.is_light_client_protocol_message_already_stored(payment_id, order,
+        existing_message = wal.storage.is_light_client_protocol_message_already_stored(message_id, payment_id, order,
                                                                                        str(message_type.value),
                                                                                        message_protocol_type)
 
@@ -275,14 +275,20 @@ class LightClientMessageHandler:
             cls.log.error("Unable to find principal message for {} {}: ".format(message.__class__.__name__,
                                                                                 message_identifier))
         else:
+            print("EXiste con")
+            print(message_identifier)
+            print(protocol_message.light_client_payment_id)
+            print(order)
             exists = LightClientMessageHandler.is_light_client_protocol_message_already_stored_message_id(
                 message_identifier, protocol_message.light_client_payment_id, order, wal)
             if not exists:
+                print("NO existia")
                 LightClientMessageHandler.store_light_client_protocol_message(
                     message_identifier, message, True, protocol_message.light_client_payment_id,
                     protocol_message.sender_light_client_address, protocol_message.receiver_light_client_address, order,
                     message_type, wal)
             else:
+                print("Ya existe")
                 cls.log.info("Message for lc already received, ignoring db storage")
 
     @classmethod

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -80,6 +80,7 @@ class MessageHandler:
                                      is_light_client: bool = False) -> None:
 
         if is_light_client:
+            receiver_is_handled_lc = LightClientService.is_handled_lc(node_address, raiden.wal)
             secret_request_light = ReceiveSecretRequestLight(
                 message.payment_identifier,
                 message.amount,
@@ -87,7 +88,8 @@ class MessageHandler:
                 message.secrethash,
                 message.sender,
                 node_address,
-                message
+                message,
+                receiver_is_handled_lc
             )
             raiden.handle_and_track_state_change(secret_request_light)
         else:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -180,6 +180,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_store_message(raiden: "RaidenService", store_message_event: StoreMessageEvent):
         existing_message = LightClientMessageHandler.is_light_client_protocol_message_already_stored(
+            store_message_event.message_id,
             store_message_event.payment_id,
             store_message_event.message_order,
             store_message_event.message_type,

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -560,7 +560,7 @@ def handle_send_secret_reveal_light(
 
     initiator_state.revealsecret = revealsecret
     initiator_state.received_secret_request = True
-    receiver_light_client_address = state_change.receiver if channel_state.both_participants_are_light_clients else None
+    receiver_light_client_address = state_change.receiver
 
     store_message_event = StoreMessageEvent(message_identifier, transfer_description.payment_identifier, 7,
                                             state_change.reveal_secret, True,

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -243,7 +243,7 @@ def handle_inittarget_light(
                                                             receiver_light_client_address=transfer.target)
 
             secret_request_message = SecretRequest.from_event(secret_request)
-            sr_receiver_light_client_address = transfer.initiator if channel_state.both_participants_are_light_clients else None
+            sr_receiver_light_client_address = transfer.initiator
             store_secret_request_event = StoreMessageEvent(message_identifier,
                                                            transfer.payment_identifier,
                                                            5,


### PR DESCRIPTION
This PR aims to solve the same hub LC to LC mediated payments. 

Suposse the following topology: 

`LC1 --- FN --- LC2
`
A mediated transfer from LC1 to LC2 implies two payments, LT1 (LC1 to FN) and LT2 (FN to LC2)

The raiden protocol establsih that two LT that are part of the same mediated transfer have the same Payment_identifier, therefore the LT received by the hub acting as a target node will not be stored. 

Why isnt stored? The msg existence query checks for: 

- same payment id (true)
- same msg order (true, the msg order is 1 for LT)
- same type (true, locked transfer)

Solution: 

Check also for message_identifier to determine if it is the same msg or not.

Note: this happens only If `LC1 `and `LC2 `are registered on the same hub

There is also another modification needed: 

- message `5 (SecretRequest) `and` 7 (RevealSecret) `are msgs between the `LC1 `and `LC2`, therefore must be assigned to both light clients.

Check comments about `handle_send_secret_reveal_light ` and `handle_inittarget_light `on the code