### PR TITLE
bugfix/RLP-835/both_participants_are_lc

### DIFF
--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -117,12 +117,14 @@ def handle_channelnew(
 
         token_network_state.channelidentifiers_to_channels[our_address][channel_identifier] = channel_state
 
-        #if channel_state.test: ## mismo hub, 2 light clients
-        if partner_address not in token_network_state.channelidentifiers_to_channels:
-            token_network_state.channelidentifiers_to_channels[partner_address] = dict()
-        channel_state_copy = copy.deepcopy(channel_state)
-        channel_state_copy.our_state, channel_state_copy.partner_state = channel_state_copy.partner_state,channel_state_copy.our_state
-        token_network_state.channelidentifiers_to_channels[partner_address][channel_identifier] = channel_state_copy
+
+        if channel_state.both_participants_are_light_clients:
+            ## 2 light clients using the same Hub
+            if partner_address not in token_network_state.channelidentifiers_to_channels:
+                token_network_state.channelidentifiers_to_channels[partner_address] = dict()
+            channel_state_copy = copy.deepcopy(channel_state)
+            channel_state_copy.our_state, channel_state_copy.partner_state = channel_state_copy.partner_state,channel_state_copy.our_state
+            token_network_state.channelidentifiers_to_channels[partner_address][channel_identifier] = channel_state_copy
 
 
 

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -123,7 +123,7 @@ def handle_channelnew(
             if partner_address not in token_network_state.channelidentifiers_to_channels:
                 token_network_state.channelidentifiers_to_channels[partner_address] = dict()
             channel_state_copy = copy.deepcopy(channel_state)
-            channel_state_copy.our_state, channel_state_copy.partner_state = channel_state_copy.partner_state,channel_state_copy.our_state
+            channel_state_copy.our_state, channel_state_copy.partner_state = channel_state_copy.partner_state, channel_state_copy.our_state
             token_network_state.channelidentifiers_to_channels[partner_address][channel_identifier] = channel_state_copy
 
 


### PR DESCRIPTION
Change log:
- The hub node now checks if both participants are light clients before duplicating the channel state