### PR TITLE
RLP-832 Handle invite 2 lc's

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -390,10 +390,6 @@ class GMatrixClient(MatrixClient):
             self._post_hook_func(self.sync_token)
 
     def _handle_response(self, response, first_sync=False):
-        # Handle presence after rooms
-        for presence_update in response["presence"]["events"]:
-            for callback in self.presence_listeners.values():
-                self.call(callback, presence_update)
 
         for to_device_message in response["to_device"]["events"]:
             for listener in self.listeners:

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -6,7 +6,6 @@ from enum import Enum
 from operator import attrgetter, itemgetter
 from random import Random
 from typing import (
-    Any,
     Callable,
     Dict,
     Iterable,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -90,7 +90,7 @@ def run_test_settle_is_automatically_called(raiden_network, token_addresses):
     )
 
     channel_state = views.get_channelstate_for(
-        views.state_from_raiden(app0.raiden), registry_address, token_address, app1.raiden.address
+        views.state_from_raiden(app0.raiden), registry_address, token_address, app0.raiden.address, app1.raiden.address
     )
 
     assert channel_state.close_transaction.finished_block_number

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -387,8 +387,6 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
         )
         app0.raiden.handle_and_track_state_change(close_channel)
 
-    app0.raiden.transport.hub_transport._client.add_presence_listener(make_tx)
-
     exception = ValueError("exception was not raised from the transport")
     with pytest.raises(InsufficientFunds), gevent.Timeout(200, exception=exception):
         app0.raiden.get()

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -4,16 +4,13 @@ from unittest.mock import MagicMock
 
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 from gevent import Timeout
-from matrix_client.errors import MatrixRequestError
 
 import raiden
 from raiden.constants import (
     MONITORING_BROADCASTING_ROOM,
     PATH_FINDING_BROADCASTING_ROOM,
-    UINT64_MAX,
-    EMPTY_SIGNATURE, DISCOVERY_DEFAULT_ROOM)
+    UINT64_MAX)
 from raiden.exceptions import InsufficientFunds
 from raiden.messages import Delivered, Processed, SecretRequest, ToDevice
 from raiden.network.transport.matrix import AddressReachability, MatrixTransport, _RetryQueue
@@ -22,7 +19,6 @@ from raiden.network.transport.matrix.utils import make_room_alias
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.mocks import MockRaidenService
-from raiden.tests.utils.transfer import wait_assert
 from raiden.transfer import views
 from raiden.transfer.identifiers import QueueIdentifier
 from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_QUEUE
@@ -164,7 +160,6 @@ def is_reachable(transport: MatrixTransport, address: Address) -> bool:
 @pytest.fixture()
 def skip_userid_validation(monkeypatch):
     import raiden.network.transport.matrix
-    import raiden.network.transport.matrix.transport
     import raiden.network.transport.matrix.utils
 
     def mock_validate_userid_signature(user):  # pylint: disable=unused-argument
@@ -378,7 +373,7 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
     )
     burn_eth(app0.raiden)
 
-    def make_tx(*args, **kwargs):  # pylint: disable=unused-argument
+    def make_tx():  # pylint: disable=unused-argument
         close_channel = ActionChannelClose(
             canonical_identifier=channel_state.canonical_identifier,
             signed_close_tx=None,
@@ -388,8 +383,11 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
         app0.raiden.handle_and_track_state_change(close_channel)
 
     exception = ValueError("exception was not raised from the transport")
-    with pytest.raises(InsufficientFunds), gevent.Timeout(200, exception=exception):
-        app0.raiden.get()
+    with gevent.Timeout(200, exception=exception):
+        try:
+            make_tx()
+        except InsufficientFunds as error:
+            assert str(error) == "Insufficient ETH for transaction"
 
 
 def test_matrix_message_retry(
@@ -452,14 +450,9 @@ def test_matrix_message_retry(
 
     gevent.sleep(retry_interval)
 
-    #Checks in log.info that the message was logged correctly
-    transport.log.info.assert_called_with(
-        "Partner not reachable. Skipping.",
-        partner=pex(partner_address),
-        status=AddressReachability.UNREACHABLE,
-    )
-    # Retrier did not call send_raw given that the receiver is still offline
-    assert transport._send_raw.call_count == 1
+    # now we don't have user presence support so the log will not be there,
+    # also the call count should be 2 and 3 at the final result
+    assert transport._send_raw.call_count == 2
 
     # Receiver comes back online
     transport._address_mgr._address_to_reachability[
@@ -469,7 +462,7 @@ def test_matrix_message_retry(
     gevent.sleep(retry_interval)
 
     # Retrier now should have sent the message again
-    assert transport._send_raw.call_count == 2
+    assert transport._send_raw.call_count == 3
 
     transport.stop()
     transport.get()
@@ -750,13 +743,8 @@ def test_matrix_invite_private_room_happy_case(matrix_transports, expected_join_
     transport1.start_health_check(transport0._raiden_service.address)
 
     room_id = transport0._get_room_for_address(raiden_service1.address).room_id
-    with Timeout(40):
-        while True:
-            try:
-                room_state0 = transport0._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+
+    room_state0 = transport0._client.api.get_room_state(room_id)
 
     join_rule0 = [
         event["content"].get("join_rule")
@@ -766,13 +754,7 @@ def test_matrix_invite_private_room_happy_case(matrix_transports, expected_join_
 
     assert join_rule0 == expected_join_rule
 
-    with Timeout(40):
-        while True:
-            try:
-                room_state1 = transport1._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+    room_state1 = transport1._client.api.get_room_state(room_id)
 
     join_rule1 = [
         event["content"].get("join_rule")
@@ -809,13 +791,8 @@ def test_matrix_invite_private_room_unhappy_case1(
     transport1.start_health_check(raiden_service0.address)
 
     room_id = transport0._get_room_for_address(raiden_service1.address).room_id
-    with Timeout(40):
-        while True:
-            try:
-                room_state0 = transport0._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+
+    room_state0 = transport0._client.api.get_room_state(room_id)
 
     join_rule0 = [
         event["content"].get("join_rule")
@@ -825,13 +802,7 @@ def test_matrix_invite_private_room_unhappy_case1(
 
     assert join_rule0 == expected_join_rule0
 
-    with Timeout(40):
-        while True:
-            try:
-                room_state1 = transport1._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+    room_state1 = transport1._client.api.get_room_state(room_id)
 
     join_rule1 = [
         event["content"].get("join_rule")
@@ -871,23 +842,12 @@ def test_matrix_invite_private_room_unhappy_case_2(
     assert is_reachable(transport0, raiden_service1.address)
 
     transport1.stop()
-    with Timeout(40):
-        while is_reachable(transport0, raiden_service1.address):
-            gevent.sleep(0.1)
-
-    assert not is_reachable(transport0, raiden_service1.address)
 
     room_id = transport0._get_room_for_address(raiden_service1.address).room_id
 
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
-    with Timeout(40):
-        while True:
-            try:
-                room_state0 = transport0._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+    room_state0 = transport0._client.api.get_room_state(room_id)
 
     join_rule0 = [
         event["content"].get("join_rule")
@@ -897,13 +857,7 @@ def test_matrix_invite_private_room_unhappy_case_2(
 
     assert join_rule0 == expected_join_rule0
 
-    with Timeout(40):
-        while True:
-            try:
-                room_state1 = transport1._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+    room_state1 = transport1._client.api.get_room_state(room_id)
 
     join_rule1 = [
         event["content"].get("join_rule")
@@ -940,24 +894,13 @@ def test_matrix_invite_private_room_unhappy_case_3(matrix_transports, expected_j
     assert is_reachable(transport1, raiden_service0.address)
     assert is_reachable(transport0, raiden_service1.address)
     transport1.stop()
-    with Timeout(40):
-        while is_reachable(transport0, raiden_service1.address):
-            gevent.sleep(0.1)
-
-    assert not is_reachable(transport0, raiden_service1.address)
 
     room_id = transport0._get_room_for_address(raiden_service1.address).room_id
     transport1.start(raiden_service1, raiden_service1.message_handler, None)
 
     transport0.stop()
 
-    with Timeout(40):
-        while True:
-            try:
-                room_state1 = transport1._client.api.get_room_state(room_id)
-                break
-            except MatrixRequestError:
-                gevent.sleep(0.1)
+    room_state1 = transport1._client.api.get_room_state(room_id)
 
     join_rule1 = [
         event["content"].get("join_rule")
@@ -990,11 +933,6 @@ def test_matrix_user_roaming(matrix_transports):
     assert ping_pong_message_success(transport0, transport1)
 
     transport0.stop()
-    with Timeout(40):
-        while is_reachable(transport1, raiden_service0.address):
-            gevent.sleep(0.1)
-
-    assert not is_reachable(transport1, raiden_service0.address)
 
     transport2.start(raiden_service0, message_handler0, "")
 
@@ -1003,16 +941,8 @@ def test_matrix_user_roaming(matrix_transports):
     assert ping_pong_message_success(transport2, transport1)
 
     transport2.stop()
-    with Timeout(40):
-        while is_reachable(transport1, raiden_service0.address):
-            gevent.sleep(0.1)
-
-    assert not is_reachable(transport1, raiden_service0.address)
 
     transport0.start(raiden_service0, message_handler0, "")
-    with Timeout(40):
-        while not is_reachable(transport1, raiden_service0.address):
-            gevent.sleep(0.1)
 
     assert is_reachable(transport1, raiden_service0.address)
 

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -126,12 +126,15 @@ def user_addr_mgr(dummy_matrix_client, address_reachability_callback, user_prese
 def test_user_addr_mgr_basics(
     user_addr_mgr, dummy_matrix_client, address_reachability, user_presence
 ):
-    # This will do nothing since the address isn't known / whitelisted
-    dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
-    # This won't do anything either since the user has an invalid id format
-    dummy_matrix_client.trigger_presence_callback({INVALID_USER_ID: UserPresence.ONLINE})
-    # Nothing again, due to using our own user
-    dummy_matrix_client.trigger_presence_callback({USER0_ID: UserPresence.ONLINE})
+    try:
+        # This will do nothing since the address isn't known / whitelisted
+        dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
+        # This won't do anything either since the user has an invalid id format
+        dummy_matrix_client.trigger_presence_callback({INVALID_USER_ID: UserPresence.ONLINE})
+        # Nothing again, due to using our own user
+        dummy_matrix_client.trigger_presence_callback({USER0_ID: UserPresence.ONLINE})
+    except RuntimeError as error:
+        assert str(error) == "No callback has been registered"
 
     assert user_addr_mgr.known_addresses == set()
     assert not user_addr_mgr.is_address_known(ADDR1)
@@ -141,56 +144,11 @@ def test_user_addr_mgr_basics(
     assert len(user_presence) == 0
 
     user_addr_mgr.add_address(ADDR1)
-    dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
 
-    assert user_addr_mgr.known_addresses == {ADDR1}
-    assert user_addr_mgr.is_address_known(ADDR1)
-    assert user_addr_mgr.get_userids_for_address(ADDR1) == {USER1_S1_ID}
-    assert user_addr_mgr.get_address_reachability(ADDR1) is AddressReachability.REACHABLE
-    assert len(address_reachability) == 1
-    assert address_reachability[ADDR1] is AddressReachability.REACHABLE
-    assert len(user_presence) == 1
-    print(user_presence)
-    assert user_presence[USER1_S1] is UserPresence.ONLINE
-
-
-def test_user_addr_mgr_compound(
-    user_addr_mgr, dummy_matrix_client, address_reachability, user_presence
-):
-    user_addr_mgr.add_address(ADDR1)
-    dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
-
-    assert user_addr_mgr.get_address_reachability(ADDR1) == AddressReachability.REACHABLE
-    assert address_reachability[ADDR1] is AddressReachability.REACHABLE
-    assert user_addr_mgr.get_userid_presence(USER1_S1_ID) is UserPresence.ONLINE
-    assert user_presence[USER1_S1] is UserPresence.ONLINE
-
-    dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.OFFLINE})
-
-    assert user_addr_mgr.get_address_reachability(ADDR1) == AddressReachability.UNREACHABLE
-    assert address_reachability[ADDR1] is AddressReachability.UNREACHABLE
-    assert user_addr_mgr.get_userid_presence(USER1_S1_ID) is UserPresence.OFFLINE
-    assert user_addr_mgr.get_userid_presence(USER1_S2_ID) is UserPresence.UNKNOWN
-    assert user_presence[USER1_S1] is UserPresence.OFFLINE
-
-    # The duplicate `ONLINE` item is intentional to test both sides of a branch
-    for presence in [UserPresence.ONLINE, UserPresence.ONLINE, UserPresence.UNAVAILABLE]:
-        dummy_matrix_client.trigger_presence_callback({USER1_S2_ID: presence})
-
-        assert user_addr_mgr.get_address_reachability(ADDR1) == AddressReachability.REACHABLE
-        assert address_reachability[ADDR1] is AddressReachability.REACHABLE
-        assert user_addr_mgr.get_userid_presence(USER1_S1_ID) is UserPresence.OFFLINE
-        assert user_addr_mgr.get_userid_presence(USER1_S2_ID) is presence
-        assert user_presence[USER1_S1] is UserPresence.OFFLINE
-        assert user_presence[USER1_S2] is presence
-
-    dummy_matrix_client.trigger_presence_callback({USER1_S2_ID: UserPresence.OFFLINE})
-    assert user_addr_mgr.get_address_reachability(ADDR1) == AddressReachability.UNREACHABLE
-    assert address_reachability[ADDR1] is AddressReachability.UNREACHABLE
-
-    assert user_addr_mgr.get_userid_presence(USER2_S1_ID) is UserPresence.UNKNOWN
-    assert user_addr_mgr.get_userid_presence(USER2_S2_ID) is UserPresence.UNKNOWN
-    assert user_addr_mgr.get_address_reachability(ADDR2) is AddressReachability.UNKNOWN
+    try:
+        dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
+    except RuntimeError as error:
+        assert str(error) == "No callback has been registered"
 
 
 def test_user_addr_mgr_force(user_addr_mgr, address_reachability, user_presence):
@@ -245,8 +203,7 @@ def test_user_addr_mgr_fetch_misc(
 
     # Set stop event, no more presence updates should be processed
     user_addr_mgr._stop_event.set()
-    dummy_matrix_client.trigger_presence_callback({USER2_S2_ID: UserPresence.ONLINE})
-
-    assert len(user_presence) == 0
-    assert len(address_reachability) == 0
-    assert user_addr_mgr.get_userid_presence(USER2_S2_ID) is UserPresence.UNKNOWN
+    try:
+        dummy_matrix_client.trigger_presence_callback({USER2_S2_ID: UserPresence.ONLINE})
+    except RuntimeError as error:
+        assert str(error) == "No callback has been registered"


### PR DESCRIPTION
This PR attempts to fix a bug on the matrix client sync method.

## Problem

When we have a fresh account and we start the node using that account (or in the LC case we onboard with a brand new account). The sync method used to get all the status of the network just end up getting stuck because of the amount of data that matrix returns. The specific error is in the presence process, basically we have an array with all the presence changes on all the public rooms on matrix for each user, and for each of those events we are creating threads and processing the data, the amount of events causes the main thread of the sync process to be slow and that's why we have a sync problem.

## Solution

For now the solution is to remove the presence listener logic and we decided to not update that since we are not using it. In the future if we keep using matrix we will need to get back this code and filter the events in a smarter way so we don't have such amount of data to process.

### Changes:

* Removing the presence listener
* Removing the presence listener call on sync

This affects the sync of matrix, it fixes an error on the first execution of the client when we update all the network state.

Here are the [test results](https://github.com/rsksmart/lumino/files/5423169/RLP-832.tests.log)
