### PR TITLE
RLP-774: generalize LC onboarding

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,25 +1,28 @@
 import copy
+import hashlib
+import os
+import random
+from binascii import hexlify
+from datetime import datetime, date
 from http import HTTPStatus
 
-import gevent
-import structlog
-from gevent import Greenlet
-import random
-import string
-import hashlib
-from binascii import hexlify
-import os
 import dateutil.parser
-from datetime import datetime, date
+import gevent
+import string
+import structlog
 from dateutil.relativedelta import relativedelta
-from eth_utils import is_binary_address, to_checksum_address, to_canonical_address, to_normalized_address, encode_hex
-
 from ecies import encrypt
+from eth_utils import is_binary_address, to_checksum_address, to_canonical_address, to_normalized_address, encode_hex
+from gevent import Greenlet
 
 import raiden.blockchain.events as blockchain_events
 from raiden import waiting, routing
 from raiden.api.validations.api_error_builder import ApiErrorBuilder
 from raiden.api.validations.channel_validator import ChannelValidator
+from raiden.billing.invoices.decoder.invoice_decoder import decode_invoice
+from raiden.billing.invoices.encoder.invoice_encoder import parse_options, encode_invoice
+from raiden.billing.invoices.options_args import OptionsArgs
+from raiden.billing.invoices.util.time_util import get_utc_unix_time, get_utc_expiration_time
 from raiden.constants import (
     GENESIS_BLOCK_NUMBER,
     RED_EYES_PER_TOKEN_NETWORK_LIMIT,
@@ -53,15 +56,14 @@ from raiden.lightclient.models.light_client_payment import LightClientPayment, L
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
 from raiden.messages import RequestMonitoring, LockedTransfer, RevealSecret, Unlock, Delivered, SecretRequest, \
     Processed, LockExpired
+from raiden.rns_constants import RNS_ADDRESS_ZERO
 from raiden.settings import DEFAULT_RETRY_TIMEOUT, DEVELOPMENT_CONTRACT_VERSION
-
 from raiden.transfer import architecture, views, routes
 from raiden.transfer.events import (
     EventPaymentReceivedSuccess,
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
 )
-
 from raiden.transfer.state import (
     BalanceProofSignedState,
     InitiatorTask,
@@ -70,10 +72,11 @@ from raiden.transfer.state import (
     TargetTask,
     TransferTask,
     ChainState)
-
 from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils import pex, typing
+from raiden.utils import random_secret, sha3
 from raiden.utils.gas_reserve import has_enough_gas_reserve
+from raiden.utils.rns import is_rns_address
 from raiden.utils.typing import (
     Address,
     Any,
@@ -99,15 +102,6 @@ from raiden.utils.typing import (
     SignedTransaction,
     InitiatorAddress)
 
-from raiden.rns_constants import RNS_ADDRESS_ZERO
-from raiden.utils.rns import is_rns_address
-
-from raiden.billing.invoices.options_args import OptionsArgs
-from raiden.billing.invoices.util.time_util import get_utc_unix_time, get_utc_expiration_time
-from raiden.billing.invoices.encoder.invoice_encoder import parse_options, encode_invoice
-from raiden.billing.invoices.decoder.invoice_decoder import decode_invoice
-from raiden.utils import random_secret, sha3
-
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 EVENTS_PAYMENT_HISTORY_RELATED = (
@@ -115,16 +109,6 @@ EVENTS_PAYMENT_HISTORY_RELATED = (
     EventPaymentSentFailed,
     EventPaymentReceivedSuccess,
 )
-
-from raiden.settings import (
-    DEFAULT_MATRIX_KNOWN_SERVERS
-)
-
-from raiden.utils.cli import get_matrix_servers
-
-from raiden.network.transport.matrix.utils import make_client
-
-from urllib.parse import urlparse
 
 
 def event_filter_for_payments(
@@ -1823,7 +1807,8 @@ class RaidenAPI:
                     {secrethash: copy.deepcopy(current_payment_task)}
                 )
                 possible_routes = routes.filter_acceptable_routes(
-                    route_states=possible_routes, blacklisted_channel_ids=current_payment_task.manager_state.cancelled_channels
+                    route_states=possible_routes,
+                    blacklisted_channel_ids=current_payment_task.manager_state.cancelled_channels
                 )
             if possible_routes:
                 # TODO marcosmartinez7 This can be improved using next_channel_from_routes in order to filter channels without capacity

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1711,12 +1711,12 @@ class RaidenAPI:
         light_clients = self.raiden.wal.storage.get_all_light_clients()
         return light_clients
 
-    def register_light_client(self,
-                              address,
-                              signed_password,
-                              server_name,
-                              signed_display_name,
-                              signed_seed_retry):
+    def save_light_client(self,
+                          address,
+                          signed_password,
+                          server_name,
+                          signed_display_name,
+                          signed_seed_retry):
 
         address = to_checksum_address(address)
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1727,19 +1727,6 @@ class RaidenAPI:
         light_clients = self.raiden.wal.storage.get_all_light_clients()
         return light_clients
 
-    def get_data_for_registration_request(self, address):
-        # fetch list of known servers from raiden-network/raiden-tranport repo
-        available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[self.raiden.config["environment_type"]]
-        available_servers = get_matrix_servers(available_servers_url)
-        client = make_client(available_servers)
-        server_url = client.api.base_url
-        server_name = urlparse(server_url).netloc
-        data_to_sign = {
-            "display_name_to_sign": "@" + to_normalized_address(address) + ":" + server_name,
-            "password_to_sign": server_name,
-            "seed_retry": "seed"}
-        return data_to_sign
-
     def register_light_client(self,
                               address,
                               signed_password,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -141,8 +141,6 @@ from raiden.utils import (
     typing)
 from raiden.utils.rns import is_rns_address
 from raiden.utils.runnable import Runnable
-from raiden.utils.signer import recover
-from transport.config import cfg as transport_config
 
 log = structlog.get_logger(__name__)
 
@@ -2126,14 +2124,14 @@ class RestAPI:
     def register_light_client(self, registration_data: dict):
         config = self.raiden_api.raiden.config["transport"]
 
-        light_client = self.raiden_api.raiden.transport.register_light_client(config, registration_data)
-        if not light_client:
+        new_light_client = self.raiden_api.raiden.transport.register_light_client(config, registration_data)
+        if not new_light_client:
             return api_error(
                 errors="The signed data provided is not valid.",
                 status_code=HTTPStatus.CONFLICT,
             )
 
-        return api_response(light_client)
+        return api_response(new_light_client)
 
     def get_light_client_protocol_message(self, from_message: int):
         headers = request.headers

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -85,7 +85,6 @@ from raiden.api.v1.resources import (
     PaymentInvoiceResource,
     ChannelsResourceLight,
     LightChannelsResourceByTokenAndPartnerAddress,
-    LightClientMatrixCredentialsBuildResource,
     LightClientResource,
     PaymentLightResource,
     CreatePaymentLightResource,
@@ -255,10 +254,9 @@ URLS_HUB_V1 = [
     ("/payments_light", PaymentLightResource),
     ("/payments_light/create", CreatePaymentLightResource, "create_payment"),
     ("/payments_light/unlock/<hexaddress:token_address>", UnlockPaymentLightResource),
-    ('/payments_light/register_onchain_secret', RegisterSecretLightResource),
-    ('/light_clients/', LightClientResource),
-    ('/light_clients/matrix/credentials', LightClientMatrixCredentialsBuildResource,),
-    ("/light_client_messages", LightClientMessageResource, "Message polling"),
+    ("/payments_light/register_onchain_secret", RegisterSecretLightResource),
+    ("/light_clients/", LightClientResource),
+    ("/light_clients/messages", LightClientMessageResource, "Message polling"),
     ("/watchtower", WatchtowerResource),
 ]
 
@@ -2330,7 +2328,7 @@ class RestAPI:
                     status_code=HTTPStatus.CONFLICT,
                     log=log
                 )
-                
+
             LightClientMessageHandler.update_onchain_light_client_protocol_message_set_signed_transaction(
                 internal_msg_identifier=internal_msg_identifier,
                 signed_message=signed_tx,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2132,7 +2132,7 @@ class RestAPI:
         return api_response(invoice)
 
     def get_data_for_registration_request(self, address):
-        data_to_sign = self.raiden_api.get_data_for_registration_request(address)
+        data_to_sign = self.raiden_api.raiden.transport.light_client_onboarding_data(address)
         return api_response(data_to_sign)
 
     def register_light_client(

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2122,9 +2122,7 @@ class RestAPI:
         return api_response(data_to_sign)
 
     def register_light_client(self, registration_data: dict):
-        config = self.raiden_api.raiden.config["transport"]
-
-        new_light_client = self.raiden_api.raiden.transport.register_light_client(config, registration_data)
+        new_light_client = self.raiden_api.raiden.transport.register_light_client(self.raiden_api, registration_data)
         if not new_light_client:
             return api_error(
                 errors="The signed data provided is not valid.",

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -551,14 +551,8 @@ class InvoiceCreateSchema(BaseSchema):
         decoding_class = dict
 
 
-class LightClientSchema(BaseSchema):
-    address = AddressField(required=True)
-    signed_password = fields.String(required=True)
-    signed_display_name = fields.String(required=True)
-    signed_seed_retry = fields.String(required=True)
-    password = fields.String(required=True)
-    display_name = fields.String(required=True)
-    seed_retry = fields.String(required=True)
+class LightClientRegistrationSchema(BaseSchema):
+    registration_data = fields.Dict(required=True)
 
     class Meta:
         strict = True
@@ -575,7 +569,7 @@ class TokenActionRequestSchema(BaseSchema):
         decoding_class = dict
 
 
-class LightClientMatrixCredentialsBuildSchema(BaseSchema):
+class LightClientOnboardingDataSchema(BaseSchema):
     address = AddressField()
 
     class Meta:

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -532,32 +532,21 @@ class LightClientResource(BaseResource):
     post_schema = LightClientSchema()
 
     @use_kwargs(get_schema, locations=("query",))
-    def get(self,
-            address: typing.Address = None):
+    def get(self, address: typing.Address = None):
         """
         This method receives a light client request for onboarding data.
         """
-        return self.rest_api.light_client_onboarding_data(address)
+        return self.rest_api.light_client_onboarding_data(
+            address
+        )
 
     @use_kwargs(post_schema, locations=("json",))
-    def post(
-        self,
-        address: typing.Address = None,
-        signed_password: typing.ByteString = None,
-        signed_display_name: typing.ByteString = None,
-        signed_seed_retry: typing.ByteString = None,
-        password: typing.ByteString = None,
-        display_name: typing.ByteString = None,
-        seed_retry: typing.ByteString = None
-    ):
+    def post(self, registration_data: dict):
+        """
+        This method receives a light client request for registration.
+        """
         return self.rest_api.register_light_client(
-            address=address,
-            signed_password=signed_password,
-            signed_display_name=signed_display_name,
-            signed_seed_retry=signed_seed_retry,
-            password=password,
-            display_name=display_name,
-            seed_retry=seed_retry
+            registration_data=registration_data
         )
 
 

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -33,11 +33,9 @@ from raiden.api.v1.encoding import (
     UnlockPaymentLightPostSchema,
     SettlementLightSchema
 )
-from raiden.messages import Unlock, LockedTransfer
-
-from raiden.utils import typing
-
 from raiden.constants import EMPTY_PAYMENT_HASH_INVOICE
+from raiden.messages import Unlock, LockedTransfer
+from raiden.utils import typing
 
 
 def create_blueprint():
@@ -163,6 +161,7 @@ class UnlockPaymentLightResource(BaseResource):
     def post(self, internal_msg_identifier: int, signed_tx: typing.SignedTransaction, **kwargs):
         return self.rest_api.post_unlock_payment_light(internal_msg_identifier, signed_tx, **kwargs)
 
+
 class SettlementLightResourceByTokenAndPartnerAddress(BaseResource):
     schema = SettlementLightSchema
 
@@ -252,6 +251,7 @@ class RegisterTokenResource(BaseResource):
         return self.rest_api.register_token(
             self.rest_api.raiden_api.raiden.default_registry.address, token_address
         )
+
 
 class GetTokenResource(BaseResource):
     def get(self, token_network):
@@ -518,6 +518,7 @@ class InvoiceResource(BaseResource):
             expires=expires
         )
 
+
 class RegisterSecretLightResource(BaseResource):
     post_schema = RegisterSecretLightSchema()
 
@@ -573,7 +574,7 @@ class WatchtowerResource(BaseResource):
             token_network_address: typing.TokenNetworkAddress,
             lc_bp_signature: typing.Signature,
             partner_balance_proof: Union[Unlock, LockedTransfer]
-    ):
+            ):
         """
         put a signed balance proof to be used by the hub, submitting it when the channel between a light client
         and a partner is closed by the partner. The signed balance proof is submitted as a tokenNetwork.updateNonClosingBalanceProf transaction.

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -535,9 +535,9 @@ class LightClientResource(BaseResource):
     def get(self,
             address: typing.Address = None):
         """
-        This method receives a registration request.
+        This method receives a light client request for onboarding data.
         """
-        return self.rest_api.get_data_for_registration_request(address)
+        return self.rest_api.light_client_onboarding_data(address)
 
     @use_kwargs(post_schema, locations=("json",))
     def post(

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -518,19 +518,6 @@ class InvoiceResource(BaseResource):
             expires=expires
         )
 
-
-class LightClientMatrixCredentialsBuildResource(BaseResource):
-    get_schema = LightClientMatrixCredentialsBuildSchema()
-
-    @use_kwargs(get_schema, locations=("query",))
-    def get(self,
-            address: typing.Address = None):
-        """
-        This method receives a registration request.
-        """
-        return self.rest_api.get_data_for_registration_request(address)
-
-
 class RegisterSecretLightResource(BaseResource):
     post_schema = RegisterSecretLightSchema()
 
@@ -540,7 +527,16 @@ class RegisterSecretLightResource(BaseResource):
 
 
 class LightClientResource(BaseResource):
+    get_schema = LightClientMatrixCredentialsBuildSchema()
     post_schema = LightClientSchema()
+
+    @use_kwargs(get_schema, locations=("query",))
+    def get(self,
+            address: typing.Address = None):
+        """
+        This method receives a registration request.
+        """
+        return self.rest_api.get_data_for_registration_request(address)
 
     @use_kwargs(post_schema, locations=("json",))
     def post(

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -23,8 +23,8 @@ from raiden.api.v1.encoding import (
     PaymentInvoiceSchema,
     ChannelLightPutSchema,
     ChannelLightPatchSchema,
-    LightClientSchema,
-    LightClientMatrixCredentialsBuildSchema,
+    LightClientRegistrationSchema,
+    LightClientOnboardingDataSchema,
     PaymentLightPutSchema,
     CreatePaymentLightPostSchema,
     WatchtowerPutResource,
@@ -528,8 +528,8 @@ class RegisterSecretLightResource(BaseResource):
 
 
 class LightClientResource(BaseResource):
-    get_schema = LightClientMatrixCredentialsBuildSchema()
-    post_schema = LightClientSchema()
+    get_schema = LightClientOnboardingDataSchema()
+    post_schema = LightClientRegistrationSchema()
 
     @use_kwargs(get_schema, locations=("query",))
     def get(self, address: typing.Address = None):

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -151,7 +151,7 @@ class MatrixLayer(TransportLayer):
         if address_recovered_from_signed_password != address or \
             address_recovered_from_signed_display_name != address or \
             address_recovered_from_signed_seed_retry != address:
-            return None
+            return None  # an error has occurred, so no light client is returned
 
         light_client = raiden_api.save_light_client(
             address,

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import click
 from eth_utils import to_normalized_address, decode_hex
 
+from raiden.api.python import RaidenAPI
 from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, MONITORING_BROADCASTING_ROOM
 from raiden.exceptions import RaidenError
 from raiden.network.transport import MatrixNode as MatrixTransportNode
@@ -119,8 +120,8 @@ class MatrixLayer(TransportLayer):
             "seed_retry": "seed",
         }
 
-    def register_light_client(self, config: dict, registration_data: dict) -> TransportNode:
-        config = config["matrix"]
+    def register_light_client(self, raiden_api: RaidenAPI, registration_data: dict) -> TransportNode:
+        config = raiden_api.raiden.config["transport"]["matrix"]
 
         password = registration_data["password"]
         signed_password = registration_data["signed_password"]
@@ -152,7 +153,7 @@ class MatrixLayer(TransportLayer):
             address_recovered_from_signed_seed_retry != address:
             return None
 
-        light_client = self.raiden_api.save_light_client(
+        light_client = raiden_api.save_light_client(
             address,
             signed_password,
             password,
@@ -172,9 +173,9 @@ class MatrixLayer(TransportLayer):
                 auth_params=auth_params,
             )
 
-            self.raiden_api.raiden.start_transport_in_runtime(
+            raiden_api.raiden.start_transport_in_runtime(
                 transport=light_client_transport,
-                chain_state=views.state_from_raiden(self.raiden_api.raiden)
+                chain_state=views.state_from_raiden(raiden_api.raiden)
             )
 
             self.add_light_client(light_client_transport)

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, List
 from urllib.parse import urlparse
 
 import click
-from eth_utils import to_normalized_address, decode_hex
+from eth_utils import to_normalized_address, decode_hex, remove_0x_prefix
 
 from raiden.api.python import RaidenAPI
 from raiden.constants import PATH_FINDING_BROADCASTING_ROOM, MONITORING_BROADCASTING_ROOM
@@ -147,7 +147,7 @@ class MatrixLayer(TransportLayer):
             signature=decode_hex(signed_seed_retry)
         )
 
-        address = registration_data['address']
+        address = bytearray.fromhex(remove_0x_prefix(registration_data['address']))
         if address_recovered_from_signed_password != address or \
             address_recovered_from_signed_display_name != address or \
             address_recovered_from_signed_seed_retry != address:

--- a/raiden/network/transport/matrix/layer.py
+++ b/raiden/network/transport/matrix/layer.py
@@ -123,8 +123,8 @@ class MatrixLayer(TransportLayer):
         config = config["matrix"]
 
         password = registration_data["password"]
-        signed_password, signed_display_name = registration_data["signed_password"], registration_data[
-            "signed_display_name"]
+        signed_password = registration_data["signed_password"]
+        signed_display_name = registration_data["signed_display_name"]
 
         # Recover light client address from password and signed_password
         address_recovered_from_signed_password = recover(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -10,7 +10,7 @@ import structlog
 from eth_utils import is_binary_address, to_canonical_address, to_checksum_address
 from gevent import Greenlet
 from gevent.event import AsyncResult, Event
-from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden_contracts.contract_manager import ContractManager
 
 from raiden import constants, routing
 from raiden.blockchain.events import BlockchainEvents
@@ -48,6 +48,7 @@ from raiden.storage import serialize, sqlite, wal
 from raiden.tasks import AlarmTask
 from raiden.transfer import node, views
 from raiden.transfer.architecture import Event as RaidenEvent, StateChange
+from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.identifiers import QueueIdentifier
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendLockedTransferLight, \
     CHANNEL_IDENTIFIER_GLOBAL_QUEUE
@@ -94,11 +95,9 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
     TokenNetworkID,
     PaymentHashInvoice, ChannelID)
-
 from raiden.utils.upgrades import UpgradeManager
-from raiden_contracts.contract_manager import ContractManager
-from transport.message import Message as TransportMessage
 from transport.layer import Layer as TransportLayer
+from transport.message import Message as TransportMessage
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 StatusesDict = Dict[TargetAddress, Dict[PaymentID, "PaymentStatus"]]

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -98,6 +98,7 @@ from raiden.utils.typing import (
 from raiden.utils.upgrades import UpgradeManager
 from raiden_contracts.contract_manager import ContractManager
 from transport.message import Message as TransportMessage
+from transport.layer import Layer as TransportLayer
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 StatusesDict = Dict[TargetAddress, Dict[PaymentID, "PaymentStatus"]]
@@ -272,7 +273,7 @@ class RaidenService(Runnable):
         default_secret_registry: SecretRegistry,
         default_service_registry: Optional[ServiceRegistry],
         default_one_to_n_address: Optional[Address],
-        transport,
+        transport: TransportLayer,
         raiden_event_handler,
         message_handler,
         config,
@@ -294,7 +295,7 @@ class RaidenService(Runnable):
         self.signer: Signer = LocalSigner(self.chain.client.privkey)
         self.address = self.signer.address
         self.discovery = discovery
-        self.transport = transport
+        self.transport: TransportLayer = transport
 
         self.user_deposit = user_deposit
 

--- a/transport/layer.py
+++ b/transport/layer.py
@@ -42,7 +42,7 @@ class Layer(ABC):
         """
 
     @abstractmethod
-    def register_light_client(self, config: dict, registration_data: dict) -> TransportNode:
+    def register_light_client(self, raiden_api: 'RaidenAPI', registration_data: dict) -> TransportNode:
         """
         Register a light client on the transport layer.
         """

--- a/transport/layer.py
+++ b/transport/layer.py
@@ -35,11 +35,16 @@ class Layer(ABC):
         Return the transport nodes for every light client registered in the running Lumino node.
         """
 
-    @staticmethod
     @abstractmethod
-    def new_light_client(address: Address, config: dict, auth_params: dict) -> TransportNode:
+    def light_client_onboarding_data(self, address: Address) -> dict:
         """
-        Instantiate a new transport node for a light client to be registered on the transport layer.
+        Return the onboarding info necessary for registering light clients on the transport layer.
+        """
+
+    @abstractmethod
+    def register_light_client(self, config: dict, registration_data: dict) -> TransportNode:
+        """
+        Register a light client on the transport layer.
         """
 
     @abstractmethod

--- a/transport/node.py
+++ b/transport/node.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from raiden.message_handler import MessageHandler
 from raiden.messages import Message
-from raiden.raiden_service import RaidenService
 from raiden.utils import Address
 
 
@@ -25,7 +24,7 @@ class Node(ABC):
         self.address = address
 
     @abstractmethod
-    def start(self, raiden_service: RaidenService, message_handler: MessageHandler, prev_auth_data: str):
+    def start(self, raiden_service: 'RaidenService', message_handler: MessageHandler, prev_auth_data: str):
         """
         Start the transport node.
         """

--- a/transport/node.py
+++ b/transport/node.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from raiden.message_handler import MessageHandler
 from raiden.messages import Message
 from raiden.utils import Address
 
@@ -24,7 +23,7 @@ class Node(ABC):
         self.address = address
 
     @abstractmethod
-    def start(self, raiden_service: 'RaidenService', message_handler: MessageHandler, prev_auth_data: str):
+    def start(self, raiden_service: 'RaidenService', message_handler: 'MessageHandler', prev_auth_data: str):
         """
         Start the transport node.
         """


### PR DESCRIPTION
This PR provides a solution for issue [RLP-774](https://jirainfuy.atlassian.net/browse/RLP-774), which is about generalizing LC onboarding calls to be transport-agnostic, with the goal of eventually adding a RIF Comms implementation.

## Overview
The main objective with these changes is to abstract (or hide away) Matrix-specific code from the light client onboarding process. This process consists of two steps in the form of API calls:
1. requesting onboarding info
2. requesting light client registration

To allow a RIF Comms onboarding process to be implemented, Matrix-specific parameters in these calls were removed and replaced with a generic dictionary. Although it is not an elegant solution, it will allow the system to keep just these 2 calls for the cases of both Matrix as well as RIF Comms.

As a result, the transport layer abstraction was extended to include these functionalities in the form of 2 new functions: `light_client_onboarding_data` and `register_light_client`. The code for these functions (in the case of the Matrix layer in particular) is the code which used to reside in the APIs.

## Details
- `environment_type` had to be added as an (internal) field to the Matrix transport layer when it is instantiated, as it will be later needed when responding to onboarding registration data requests.
- although it is rather unsightly, the Raiden API is needed at the moment of registering a new light client in the transport layer. this field is not accessible from the transport layer due to bad design/coupling, so it is passed as a parameter.
- the `new_light_client` method was removed from the transport layer abstraction, since it's no longer necessary to call it externally (the 2 previously mentioned API calls contain this functionality).
  - although they are not currently used, the `add_light_client` and `remove_light_client` functions still remain in the generic and matrix-specific transport layers.
- the `light_clients/` and `light_clients/matrix/credentials/` endpoints were merged into a single endpoint (`light_clients/`) which uses `GET` and `POST`.
  - `light_clients_messages` was renamed to `light_clients/messages` for consistency's sake.
- a type hint for the transport layer field was added to the `RaidenService` class.
- several Rest and Raiden API calls and classes were renamed in order to better reflect what they do.
- some type hints in the transport node had to be changed to strings in order to prevent cyclical imports.
- _Reformat code_ and _Optimize Imports_ have been applied to the modified files.

## Next steps
This PR will break the SDK. The code there will have to be updated to use the new endpoint names and structures.

Additionally, although the Matrix onboarding logic is currently hidden behind this specific transport layer implementation, it's clear some functions will have to change for the [RIF Comms onboarding implementation](https://jirainfuy.atlassian.net/browse/RLP-846) to work. Namely:
- `RaidenAPI.get_all_light_clients`
- `RaidenAPI.save_light_client`
- `RaidenAPI.validate_light_client`
- `SQLiteStorage.get_light_client`
- `SQLiteStorage.save_light_client`
- `SQLiteStorage.get_all_light_clients`
- `SQLiteStorage.get_light_client_by_api_key`

and there might be others as well.

These functions use Matrix-specific parameters. We can either refactor them, or rename them and add RIF Comms counterparts.

---

This PR builds on #110. Once it is merged, we can also merge #110 and close related issues [RLP-750](https://jirainfuy.atlassian.net/browse/RLP-750) and [RLP-775](https://jirainfuy.atlassian.net/browse/RLP-775).