### PR TITLE
RLP-887: set environment_type on MatrixTransport

### DIFF
--- a/transport/matrix/layer.py
+++ b/transport/matrix/layer.py
@@ -87,9 +87,11 @@ class MatrixLayer(TransportLayer[MatrixTransportNode]):
     def _prepare_config(self, config):
         from raiden.ui.app import log
 
+        self.environment_type = config["environment_type"]
+
         if config["transport"]["matrix"].get("available_servers") is None:
             # fetch list of known servers from raiden-network/raiden-tranport repo
-            available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[config["environment_type"]]
+            available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[self.environment_type]
             available_servers = get_matrix_servers(available_servers_url)
             log.debug("Fetching available matrix servers", available_servers=available_servers)
             config["transport"]["matrix"]["available_servers"] = available_servers


### PR DESCRIPTION
This PR fixes a bug introduced in #139, where a sentence in the original Matrix Transport Layer constructor was not included in the new `_prepare_config` function, which replaced the constructor.

Jira issue [here](https://jirainfuy.atlassian.net/browse/RLP-887).