### PR TITLE
RifCommsNode base

### DIFF
--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -44,25 +44,29 @@ def rif_comms_client(request):
 @pytest.mark.usefixtures("rif_comms_client")
 class TestRiffCommsClient(unittest.TestCase):
 
+    @pytest.mark.skip(reason="ignore")
     def test_initialization(self):
         assert self.rif_comms_client is not None
 
+    @pytest.mark.skip(reason="ignore")
     def test_locate_peer_id(self):
         response = self.rif_comms_client.connect()
         peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
         print(f"test_locate_peer_id peer_id = {peer_id}")
         assert peer_id is not None
 
+    @pytest.mark.skip(reason="ignore")
     def test_locate_unregistered_peer_id(self):
         self.assertRaises(_InactiveRpcError, lambda: self.rif_comms_client.get_peer_id(UNREGISTERED_ADDRESS))
 
+    @pytest.mark.skip(reason="ignore")
     def test_create_random_topic_id_without_connection(self):
         notification = self.rif_comms_client.connect()
         peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
         channel = self.rif_comms_client.subscribe(get_random_address_str())
         peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
 
-    #@pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="ignore")
     def test_subscribe(self):
         channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
         stub = CommunicationsApiStub(channel)
@@ -71,6 +75,7 @@ class TestRiffCommsClient(unittest.TestCase):
         channel = stub.CreateTopicWithRskAddress(rsk_address)
         subscribers = stub.GetSubscribers(Channel(channelId=LUMINO_1_ADDRESS))
 
+    @pytest.mark.skip(reason="ignore")
     def test_has_subscriber(self):
         channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
         stub = CommunicationsApiStub(channel)
@@ -92,3 +97,10 @@ class TestRiffCommsClient(unittest.TestCase):
         )
         print("has_subscriber")
         print(has_subscriber)
+
+    def test_disconnect(self):
+        notification = self.rif_comms_client.connect()
+        peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
+        self.rif_comms_client.disconnect()
+
+

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -115,10 +115,12 @@ class TestRiffCommsClient(unittest.TestCase):
         peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
         self.rif_comms_client.disconnect()
 
+    @pytest.mark.skip(reason="ignore")
     def test_send_lumino_message(self):
         channel = grpc.insecure_channel(LUMINO_2_COMMS_API)
         stub = CommunicationsApiStub(channel)
-        channel = stub.Subscribe(Channel(channelId="16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA")) # got this from subscription of lumino node
+        channel = stub.Subscribe(Channel(
+            channelId="16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA"))  # got this from subscription of lumino node
 
         some_raiden_message = {
             'type': 'LockedTransfer',
@@ -152,4 +154,3 @@ class TestRiffCommsClient(unittest.TestCase):
                 message=Msg(payload=str.encode(json.dumps(some_raiden_message)))
             )
         )
-

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -9,7 +9,7 @@ from grpc._channel import _InactiveRpcError
 from sha3 import keccak_256
 
 from transport.rif_comms.client import RifCommsClient
-from transport.rif_comms.proto.api_pb2 import RskAddress
+from transport.rif_comms.proto.api_pb2 import RskAddress, Channel, Subscriber
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
 
@@ -62,15 +62,33 @@ class TestRiffCommsClient(unittest.TestCase):
         channel = self.rif_comms_client.subscribe(get_random_address_str())
         peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
 
-    @pytest.mark.skip(reason="ignore")
-    def test_create_random_topic_id_without_connection_1(self):
+    #@pytest.mark.skip(reason="ignore")
+    def test_subscribe(self):
         channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
         stub = CommunicationsApiStub(channel)
         rsk_address = RskAddress(address=LUMINO_1_ADDRESS)
-        peer_addr = RskAddress(address=get_random_address_str())
         notification = stub.ConnectToCommunicationsNode(rsk_address)
-        response = stub.LocatePeerId(rsk_address)
-        print("response=%s" % response)
-        channel = stub.CreateTopicWithRskAddress(peer_addr)
-        for resp in channel:
-            print(resp)
+        channel = stub.CreateTopicWithRskAddress(rsk_address)
+        subscribers = stub.GetSubscribers(Channel(channelId=LUMINO_1_ADDRESS))
+
+    def test_has_subscriber(self):
+        channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
+        stub = CommunicationsApiStub(channel)
+        rsk_address = RskAddress(address=LUMINO_1_ADDRESS)
+        notification = stub.ConnectToCommunicationsNode(rsk_address)
+        channel = stub.CreateTopicWithPeerId(rsk_address)
+        peer_id = stub.LocatePeerId(rsk_address)
+
+        """
+        message Subscriber {
+            string peerId = 1;
+            Channel channel = 2;
+        }"""
+        has_subscriber = stub.HasSubscriber(
+            Subscriber(
+                peerId=peer_id.address,
+                channel=Channel(channelId=LUMINO_1_ADDRESS)
+            )
+        )
+        print("has_subscriber")
+        print(has_subscriber)

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -99,15 +99,15 @@ class TestRiffCommsClient(unittest.TestCase):
         message Subscriber {
             string peerId = 1;
             Channel channel = 2;
-        }"""
+        }
+        """
         has_subscriber = stub.HasSubscriber(
             Subscriber(
                 peerId=peer_id.address,
                 channel=Channel(channelId=LUMINO_1_ADDRESS)
             )
         )
-        print("has_subscriber")
-        print(has_subscriber)
+        print("has_subscriber", has_subscriber)
 
     @pytest.mark.skip(reason="ignore")
     def test_disconnect(self):
@@ -152,5 +152,4 @@ class TestRiffCommsClient(unittest.TestCase):
                 message=Msg(payload=str.encode(json.dumps(some_raiden_message)))
             )
         )
-
 

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -38,12 +38,22 @@ def rif_comms_client(request):
     def teardown():
         rif_comms_client.disconnect()
 
-    #request.addfinalizer(teardown)
+    request.addfinalizer(teardown)
     request.cls.rif_comms_client = rif_comms_client
 
 
 @pytest.mark.usefixtures("rif_comms_client")
 class TestRiffCommsClient(unittest.TestCase):
+    """
+    Test for RIFCommsClient. This class is for test the basic operations of the client.
+
+    How to use it:
+
+    - Modify the LUMINO_1_COMMS_API, LUMINO_2_COMMS_API, LUMINO_1_ADDRESS and LUMINO_2_ADDRESS
+    - Some tests uses LUMINO_1_ADDRESS as a representation of the Lumino keystore
+    - Others uses both LUMINO_1_ADDRESS and LUMINO_2_ADDRESS to represent two separeted peers
+    - ALl the tests assumes that there is a RIF COMMS node already running
+    """
 
     @pytest.mark.skip(reason="ignore")
     def test_initialization(self):

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -11,6 +11,7 @@ from gevent.event import Event
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixRequestError
 from matrix_client.user import User
+
 from raiden.constants import DISCOVERY_DEFAULT_ROOM
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress
 from raiden.message_handler import MessageHandler

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -877,11 +877,6 @@ class MatrixNode(TransportNode, Runnable):
                     exc_info=True,
                 )
 
-    def _sign(self, data: bytes) -> bytes:
-        """ Use eth_sign compatible hasher to sign matrix data """
-        assert self._raiden_service is not None
-        return self._raiden_service.signer.sign(data=data)
-
     def _get_user(self, user: Union[User, str]) -> User:
         """Creates an User from an user_id, if none, or fetch a cached User
 

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -1,8 +1,16 @@
 from grpc import insecure_channel
 
 from raiden.utils import Address
-from transport.rif_comms.proto.api_pb2 import Notification, PublishPayload, Channel, Msg, RskAddress, Void, Subscriber, \
+from transport.rif_comms.proto.api_pb2 import (
+    Notification,
+    PublishPayload,
+    Channel,
+    Msg,
+    RskAddress,
+    Void,
+    Subscriber,
     BooleanResponse
+)
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
 

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -2,7 +2,8 @@ from grpc import insecure_channel
 
 from raiden.utils import Address
 from transport.message import Message
-from transport.rif_comms.proto.api_pb2 import Notification, PublishPayload, Channel, Msg, RskAddress, Void
+from transport.rif_comms.proto.api_pb2 import Notification, PublishPayload, Channel, Msg, RskAddress, Void, Subscriber, \
+    BooleanResponse
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
 
@@ -39,7 +40,17 @@ class RifCommsClient:
         # TODO catch already subscribed and any error
         return self.stub.CreateTopicWithRskAddress(RskAddress(address=topic_id))
 
-    def send_message(self, topic_id: str, message: Message) -> Void:
+    # TODO review params and create docstring. It has no sense to use both peer id and rsk_address
+    def has_subscription(self, rsk_address: Address) -> BooleanResponse:
+        peer_id = self.get_peer_id(rsk_address)
+        return self.stub.HasSubscriber(
+            Subscriber(
+                peerId=peer_id,
+                channel=Channel(channelId=rsk_address)
+            )
+        )
+
+    def send_message(self, topic_id: str, data: str) -> Void:
         """
         Sends a message to a topic.
         Invokes the SendMessageToTopic grpc api endpoint

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -1,7 +1,6 @@
 from grpc import insecure_channel
 
 from raiden.utils import Address
-from transport.message import Message
 from transport.rif_comms.proto.api_pb2 import Notification, PublishPayload, Channel, Msg, RskAddress, Void, Subscriber, \
     BooleanResponse
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
@@ -82,8 +81,7 @@ class RifCommsClient:
         Invokes the EndCommunication grpc api endpoint.
         :return: void
         """
-        # TODO param for end
-       # self.stub.EndCommunication()
+        self.stub.EndCommunication(Void())
         self.grpc_channel.unsubscribe(lambda: self.grpc_channel.close())
 
     def get_peer_id(self, rsk_address: Address) -> str:

--- a/transport/rif_comms/layer.py
+++ b/transport/rif_comms/layer.py
@@ -10,7 +10,7 @@ class RifCommsLayer(TransportLayer[RifCommsNode]):
         return RifCommsNode(config["address"], config["transport"]["rif_comms"])
 
     def construct_light_clients_nodes(self, config):
-        pass
+        return []
 
     def light_client_onboarding_data(self, address: Address) -> dict:
         pass

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -42,10 +42,10 @@ class RifCommsNode(TransportNode, Runnable):
         self._client = RifCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
         print("RifCommsNode init on grpc endpoint: {}".format(self._config["grpc_endpoint"]))
 
-        self._greenlets: List[Greenlet] = list()  # TODO why we need this? how it works the _spawn
-        self._address_to_message_queue: Dict[Address, _RetryQueue] = dict()  # TODO RetryQueue is on matrix package
+        self._greenlets: List[Greenlet] = list()
+        self._address_to_message_queue: Dict[Address, _RetryQueue] = dict()
 
-        self._stop_event = Event()  # TODO used on handle message and another points, pending review
+        self._stop_event = Event()
         self._stop_event.set()
 
         self.log = log.bind(node_address=pex(self.address))
@@ -63,9 +63,6 @@ class RifCommsNode(TransportNode, Runnable):
 
         self._rif_comms_connect_stream = self._client.connect()
         self._our_topic = self._client.subscribe(to_checksum_address(raiden_service.address))
-
-        self._client.get_peer_id(
-            to_checksum_address(raiden_service.address))  # TODO remove when blocking grpc api bug solved
 
         for message_queue in self._address_to_message_queue.values():
             if not message_queue:
@@ -86,8 +83,6 @@ class RifCommsNode(TransportNode, Runnable):
         return f"<{self.__class__.__name__}{node} id:{id(self)}>"
 
     def _run(self) -> None:
-        # TODO ActionUpdateTransportAuthData?
-        # TODO which is the  Runnable main method, that perform wait on long-running subtasks ?"
         """ Runnable main method, perform wait on long-running subtasks """
         # dispatch auth data on first scheduling after start
         self.greenlet.name = f"RifCommsNode._run node:{pex(self._raiden_service.address)}"
@@ -291,7 +286,7 @@ class RifCommsNode(TransportNode, Runnable):
         if self._our_topic:
             self._our_topic.kill()
             self._our_topic.get()
-        if self._our_topicis not None:
+        if self._our_topic is not None:
             self._our_topic.get()
         self._our_topic= None
 

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -1,20 +1,28 @@
-from typing import Any, List, Dict
+from typing import Any, List, Dict, NewType
 
+import gevent
+import structlog
 from gevent import Greenlet
 from gevent.event import Event
+from greenlet import GreenletExit
 
 from raiden.message_handler import MessageHandler
 from raiden.messages import Message
 from raiden.raiden_service import RaidenService
 from raiden.utils.runnable import Runnable
-from raiden.utils.typing import Address
+from raiden.utils import Address, pex
 from transport.matrix.utils import _RetryQueue
 from transport.node import Node as TransportNode
 from transport.rif_comms.client import RifCommsClient
 from eth_utils import to_checksum_address
 
 
+_RoomID = NewType("_RoomID", str)
+log = structlog.get_logger(__name__)
+
 class RifCommsNode(TransportNode, Runnable):
+
+    log = log
 
     def __init__(self, address: Address, config: dict):
         TransportNode.__init__(self, address)
@@ -31,6 +39,10 @@ class RifCommsNode(TransportNode, Runnable):
         self._stop_event = Event() # TODO used on handle message and another points, pending review
         self._stop_event.set()
 
+        self.log = log.bind(node_address=pex(self.address))
+
+
+
     def start(self, raiden_service: RaidenService, message_handler: MessageHandler, prev_auth_data: str):
         if not self._stop_event.ready():
             raise RuntimeError(f"{self!r} already started")
@@ -40,14 +52,79 @@ class RifCommsNode(TransportNode, Runnable):
         self._client.get_peer_id(to_checksum_address(raiden_service.address)) # TODO remove when blocking grpc api bug solved
 
         # TODO matrix node here invokes inventory_rooms that sets the handle_message callback
-
+        # TODO here we must also check for new messages as the matrix node does with   self._client.start_listener_thread()
+        #         self._client.sync_thread.link_exception(self.on_error)
+        #         self._client.sync_thread.link_value(on_success)
+        #         self.greenlets = [self._client.sync_thread]
         for message_queue in self._address_to_message_queue.values():
             if not message_queue:
                 self.log.debug("Starting message_queue", message_queue=message_queue)
                 message_queue.start()
+        self.log.debug("RIF Comms Node started", config=self._config)
+        Runnable.start(self)
+
+
+    def __repr__(self):
+        if self._raiden_service is not None:
+            node = f" node:{pex(self._raiden_service.address)}"
+        else:
+            node = ""
+
+        return f"<{self.__class__.__name__}{node} id:{id(self)}>"
+
+
+    def _run(self, *args: Any, **kwargs: Any) -> None:
+        # TODO ActionUpdateTransportAuthData?
+        # TODO which is the  Runnable main method, that perform wait on long-running subtasks ?"
+        """ Runnable main method, perform wait on long-running subtasks """
+        # dispatch auth data on first scheduling after start
+        self.greenlet.name = f"RifCommsNode._run node:{pex(self._raiden_service.address)}"
+        try:
+            # waits on _stop_event.ready()
+            # children crashes should throw an exception here
+        except GreenletExit:  # killed without exception
+            self._stop_event.set()
+            gevent.killall(self.greenlets)  # kill children
+            raise  # re-raise to keep killed status
+        except Exception:
+            self.stop()  # ensure cleanup and wait on subtasks
+            raise
 
     def stop(self):
-        raise NotImplementedError
+        """
+        Try to gracefully stop the greenlet synchronously
+
+        Stop isn't expected to re-raise greenlet _run exception
+        (use self.greenlet.get() for that),
+        but it should raise any stop-time exception
+
+        Disconnects from RIF Communications node
+        """
+        if self._stop_event.ready():
+            return
+        self._stop_event.set()
+
+        for message_queue in self._address_to_message_queue.values():
+            if message_queue: # if message_queue.greenlet is not None
+                message_queue.notify() # if we need to send something, this is the time
+
+        # TODO we must stop the listener thread if present on this implementation
+        # self._client.stop_listener_thread()  # stop sync_thread, wait client's greenlets
+
+        # wait own greenlets, no need to get on them, exceptions should be raised in _run()
+        gevent.wait(self.greenlets + [r.greenlet for r in self._address_to_message_queue.values()])
+
+        # TODO we must end rif comms communication and grpc session
+
+        self.log.debug("RIF Comms Node stopped", config=self._config)
+        try:
+            del self.log
+        except AttributeError:
+            # During shutdown the log attribute may have already been collected
+            pass
+        # parent may want to call get() after stop(), to ensure _run errors are re-raised
+        # we don't call it here to avoid deadlock when self crashes and calls stop() on finally
+
 
     def send_message(self, message: Message, recipient: Address):
         raise NotImplementedError
@@ -64,8 +141,7 @@ class RifCommsNode(TransportNode, Runnable):
     def join(self, timeout=None):
         raise NotImplementedError
 
-    def _run(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError
+
 
 
 class RifCommsLightClientNode(RifCommsNode):

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -35,9 +35,9 @@ class RifCommsNode(TransportNode, Runnable):
         self._config = config
         self._raiden_service: RaidenService = None
 
-        self._rif_comms_connect_stream : Notification = None
-        self._our_topic : Notification = None
-        self._our_topic_thread : Greenlet = None
+        self._rif_comms_connect_stream: Notification = None
+        self._our_topic: Notification = None
+        self._our_topic_thread: Greenlet = None
 
         self._client = RifCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
         print("RifCommsNode init on grpc endpoint: {}".format(self._config["grpc_endpoint"]))
@@ -64,7 +64,8 @@ class RifCommsNode(TransportNode, Runnable):
         self._rif_comms_connect_stream = self._client.connect()
         self._our_topic = self._client.subscribe(to_checksum_address(raiden_service.address))
 
-        self._client.get_peer_id(to_checksum_address(raiden_service.address))  # TODO remove when blocking grpc api bug solved
+        self._client.get_peer_id(
+            to_checksum_address(raiden_service.address))  # TODO remove when blocking grpc api bug solved
 
         # TODO matrix node here invokes inventory_rooms that sets the handle_message callback
         # TODO here we must also check for new messages as the matrix node does with   self._client.start_listener_thread()
@@ -262,7 +263,6 @@ class RifCommsNode(TransportNode, Runnable):
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):
             self.log.warning("Exception while processing message", exc_info=True)
             return
-
 
     def start_health_check(self, address: Address):
         self.log.debug("Healthcheck", peer_address=pex(address))

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -31,7 +31,6 @@ from transport.node import Node as TransportNode
 from transport.rif_comms.client import RifCommsClient
 from transport.rif_comms.proto.api_pb2 import Notification, ChannelNewData
 
-_RoomID = NewType("_RoomID", str)
 log = structlog.get_logger(__name__)
 
 
@@ -142,7 +141,7 @@ class RifCommsNode(TransportNode, Runnable):
         # we don't call it here to avoid deadlock when self crashes and calls stop() on finally
 
     def send_message(self, message: TransportMessage, recipient: Address):
-        """Queue the message for sending to recipient in the queue_identifier
+        """Queue the message for sending to recipient
 
         It may be called before transport is started, to initialize message queues
         The actual sending is started only when the transport is started
@@ -274,7 +273,7 @@ class RifCommsNode(TransportNode, Runnable):
     def join(self, timeout=None):
         self.greenlet.join(timeout)
 
-    def listen_messages(
+    def listen_for_messages(
         self
     ):
         """
@@ -289,7 +288,7 @@ class RifCommsNode(TransportNode, Runnable):
         """
         Start a listener greenlet to listen for received messages in the background.
         """
-        self._our_topic_thread = spawn(self.listen_messages)
+        self._our_topic_thread = spawn(self.listen_for_messages)
         self._our_topic_thread.name = f"RifCommsClient.listen_messages rsk_address:{self.address}"
 
     def stop_listener_thread(self):

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -72,7 +72,7 @@ class RifCommsNode(TransportNode, Runnable):
 
         self._rif_comms_connect_stream = self._client.connect()
         self._our_topic = self._client.subscribe(to_checksum_address(raiden_service.address))
-        # self._client.get_peer_id(to_checksum_address(raiden_service.address))
+        self._client.get_peer_id(to_checksum_address(raiden_service.address)) # TODO remove this after grpc api request blocking is fixed
         for message_queue in self._address_to_message_queue.values():
             if not message_queue:
                 self.log.debug("Starting message_queue", message_queue=message_queue)

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -83,10 +83,7 @@ class RifCommsNode(TransportNode, Runnable):
         Runnable.start(self)
 
     def __repr__(self):
-        if self._raiden_service is not None:
-            node = f" node:{pex(self._raiden_service.address)}"
-        else:
-            node = ""
+        node = f" node:{pex(self._raiden_service.address)}" if self._raiden_service else ""
 
         return f"<{self.__class__.__name__}{node} id:{id(self)}>"
 
@@ -121,12 +118,12 @@ class RifCommsNode(TransportNode, Runnable):
         self._stop_event.set()
 
         for message_queue in self._address_to_message_queue.values():
-            if message_queue:  # if message_queue.greenlet is not None
+            if message_queue.greenlet:
                 message_queue.notify()  # if we need to send something, this is the time
 
-        self.stop_listener_thread()  # stop sync_thread, wait client's greenlets
+        self.stop_listener_thread()  # stop sync_thread, wait for client's greenlets
 
-        # wait own greenlets, no need to get on them, exceptions should be raised in _run()
+        # wait for our own greenlets, no need to get on them, exceptions should be raised in _run()
         wait(self._greenlets + [r.greenlet for r in self._address_to_message_queue.values()])
 
         self._client.disconnect()


### PR DESCRIPTION
# Description

The objective of this PR is to introduce a first approach to implement the `RifCommsNode` class, the implementation of `TransportNode` that uses RIF Communications pub sub node. 

On this PR, the abstract methods of `TransportNode` are implemented and must be iterated on following PRs.

# Changelog

Implemented:
1. `__init__ `that starts a rif comms client and define the instance attributes of the class: 
  - `_config`
  - `_raiden_service`
  - `_client`
  - `_address_to_message_queue`
  - `_stop_event`
  - `_greenlets`

2. `start` with some pending TODOs
3. `_run` with some pending TODOs
4.  `stop` with some pending TODOs
5. `send_message` (pending `_send_with_retry `and` _send_raw`)
6. no-op `start_health_check` and `whitelist`
7. `link_exception `and `join`
8. `send_raw`, `enqueue_message`, `get_queue` with some pending TODOs
9. `handle_message`, `handle_delivered` with some pending TODOs
10. rest of the relevant methods (to review with @mortelli )
11.  RiffCommsNode listen to received messages on background

# TODO's

1. Global worker and prioritze global msgs? 
2. Join_global_room at start, maybe we can use a bootstrap node for rif comms here?
3. ~~Log class variable?~~
4. what about _run if we dont handle global msgs? 
5. ~~what are self.greenlets used for? Does we really need it? we only need one for leave topics?~~
6. ~~does stop need to invoke the end comms and unsubscribe from grpc channel?~~
7.  ~~self._client.start_listener_thread() ? we need a thread for listen messages~~
8. is spawn needed? it is only used on leave unused rooms, we must unsubscribe when the channels are closed?
9. How does get_all_messagequeues works and how are populated the queues on the raiden service?
10. validate_and_parse_message must be modified to use an address instead of a matrix user


![image](https://user-images.githubusercontent.com/14795944/99116791-62274500-25d3-11eb-9c20-6d5dcfd7756c.png)

