### PR TITLE
RLP-889: generalize RetryQueue

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import structlog
 from eth_utils import to_checksum_address, to_hex, encode_hex
-
 from raiden.api.objects import SettlementParameters
 from raiden.billing.invoices.handlers.invoice_handler import handle_receive_events_with_payments
 from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_MESSAGE_HASH, EMPTY_SIGNATURE
@@ -140,6 +139,7 @@ def unlock_light(raiden: "RaidenService",
             message=message
         )
 
+
 class EventHandler(ABC):
     @abstractmethod
     def on_raiden_event(self, raiden: "RaidenService", chain_state: ChainState, event: Event):
@@ -257,7 +257,7 @@ class RaidenEventHandler(EventHandler):
             stored_but_unsigned = existing_message.signed_message is None
             if stored_but_unsigned and store_message_event.is_signed:
                 # Update messages that were created by the hub and now are received signed by the light client
-                LightClientMessageHandler\
+                LightClientMessageHandler \
                     .update_offchain_light_client_protocol_message_set_signed_message(store_message_event.message,
                                                                                       store_message_event.payment_id,
                                                                                       store_message_event.message_order,
@@ -450,15 +450,17 @@ class RaidenEventHandler(EventHandler):
             wal=raiden.wal)
         # Do not store the RegisterSecretRequest twice for same payment
         if not existing_message:
+            LightClientMessageHandler.store_light_client_protocol_message(
+                identifier=channel_reveal_secret_event.message_id,
+                message=message,
+                signed=False,
+                payment_id=channel_reveal_secret_event.payment_identifier,
+                light_client_address=channel_reveal_secret_event.light_client_address,
+                order=0,
+                message_type=LightClientProtocolMessageType.RequestRegisterSecret,
+                wal=raiden.wal
+            )
 
-            LightClientMessageHandler.store_light_client_protocol_message(identifier=channel_reveal_secret_event.message_id,
-                                                                          message=message,
-                                                                          signed=False,
-                                                                          payment_id=channel_reveal_secret_event.payment_identifier,
-                                                                          light_client_address=channel_reveal_secret_event.light_client_address,
-                                                                          order=0,
-                                                                          message_type=LightClientProtocolMessageType.RequestRegisterSecret,
-                                                                          wal=raiden.wal)
     @staticmethod
     def handle_contract_send_channelclose(
         raiden: "RaidenService",

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -270,7 +270,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_lockexpired(raiden: "RaidenService", send_lock_expired: SendLockExpired):
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(send_lock_expired.queue_identifier, lock_expired_message)
         )
 
@@ -279,7 +279,7 @@ class RaidenEventHandler(EventHandler):
         signed_lock_expired = send_lock_expired.signed_lock_expired
         lc_transport = raiden.get_light_client_transport(to_checksum_address(signed_lock_expired.sender))
         if lc_transport:
-            lc_transport.send_message(
+            lc_transport.enqueue_message(
                 *TransportMessage.wrap(send_lock_expired.queue_identifier, signed_lock_expired)
             )
 
@@ -289,7 +289,7 @@ class RaidenEventHandler(EventHandler):
     ):
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(send_locked_transfer.queue_identifier, mediated_transfer_message)
         )
 
@@ -301,7 +301,7 @@ class RaidenEventHandler(EventHandler):
         light_client_address = to_checksum_address(send_locked_transfer_light.signed_locked_transfer.initiator)
         for light_client_transport in raiden.transport.light_clients:
             if light_client_address == light_client_transport.address:
-                light_client_transport.send_message(
+                light_client_transport.enqueue_message(
                     *TransportMessage.wrap(send_locked_transfer_light.queue_identifier, mediated_transfer_message)
                 )
 
@@ -309,7 +309,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_secretreveal(raiden: "RaidenService", reveal_secret_event: SendSecretReveal):
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(reveal_secret_event.queue_identifier, reveal_secret_message)
         )
 
@@ -318,7 +318,7 @@ class RaidenEventHandler(EventHandler):
         signed_secret_reveal = reveal_secret_event.signed_secret_reveal
         lc_transport = raiden.get_light_client_transport(to_checksum_address(reveal_secret_event.sender))
         if lc_transport:
-            lc_transport.send_message(
+            lc_transport.enqueue_message(
                 *TransportMessage.wrap(reveal_secret_event.queue_identifier, signed_secret_reveal)
             )
 
@@ -326,7 +326,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_balanceproof(raiden: "RaidenService", balance_proof_event: SendBalanceProof):
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(balance_proof_event.queue_identifier, unlock_message)
         )
 
@@ -335,7 +335,7 @@ class RaidenEventHandler(EventHandler):
         unlock_message = message_from_sendevent(balance_proof_event)
         lc_transport = raiden.get_light_client_transport(to_checksum_address(balance_proof_event.sender))
         if lc_transport:
-            lc_transport.send_message(
+            lc_transport.enqueue_message(
                 *TransportMessage.wrap(balance_proof_event.queue_identifier, unlock_message)
             )
 
@@ -348,7 +348,7 @@ class RaidenEventHandler(EventHandler):
 
         secret_request_message = message_from_sendevent(secret_request_event)
         raiden.sign(secret_request_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(secret_request_event.queue_identifier, secret_request_message)
         )
 
@@ -359,7 +359,7 @@ class RaidenEventHandler(EventHandler):
         secret_request_message = message_from_sendevent(secret_request_event)
         lc_transport = raiden.get_light_client_transport(to_checksum_address(secret_request_event.sender))
         if lc_transport:
-            lc_transport.send_message(
+            lc_transport.enqueue_message(
                 *TransportMessage.wrap(secret_request_event.queue_identifier, secret_request_message)
             )
 
@@ -369,7 +369,7 @@ class RaidenEventHandler(EventHandler):
     ):
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(refund_transfer_event.queue_identifier, refund_transfer_message)
         )
 
@@ -377,7 +377,7 @@ class RaidenEventHandler(EventHandler):
     def handle_send_processed(raiden: "RaidenService", processed_event: SendProcessed):
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
-        raiden.transport.full_node.send_message(
+        raiden.transport.full_node.enqueue_message(
             *TransportMessage.wrap(processed_event.queue_identifier, processed_message)
         )
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1329,7 +1329,7 @@ class RaidenService(Runnable):
             queue_identifier = QueueIdentifier(
                 recipient=receiver_address, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
             )
-            lc_transport.send_message(*TransportMessage.wrap(queue_identifier, delivered))
+            lc_transport.enqueue_message(*TransportMessage.wrap(queue_identifier, delivered))
 
     def initiate_send_processed_light(self, sender_address: Address, receiver_address: Address,
                                       processed: Processed, msg_order: int, payment_id: int,
@@ -1349,7 +1349,7 @@ class RaidenService(Runnable):
             queue_identifier = QueueIdentifier(
                 recipient=receiver_address, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
             )
-            lc_transport.send_message(*TransportMessage.wrap(queue_identifier, processed))
+            lc_transport.enqueue_message(*TransportMessage.wrap(queue_identifier, processed))
 
     def initiate_send_secret_reveal_light(
         self,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -10,8 +10,6 @@ import structlog
 from eth_utils import is_binary_address, to_canonical_address, to_checksum_address
 from gevent import Greenlet
 from gevent.event import AsyncResult, Event
-from raiden_contracts.contract_manager import ContractManager
-
 from raiden import constants, routing
 from raiden.blockchain.events import BlockchainEvents
 from raiden.blockchain_events_handler import on_blockchain_event
@@ -96,6 +94,7 @@ from raiden.utils.typing import (
     TokenNetworkID,
     PaymentHashInvoice, ChannelID)
 from raiden.utils.upgrades import UpgradeManager
+from raiden_contracts.contract_manager import ContractManager
 from transport.layer import Layer as TransportLayer
 from transport.message import Message as TransportMessage
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -25,7 +25,7 @@ from transport.matrix.client import Room
 from transport.matrix.node import MatrixNode as MatrixTransportNode
 from transport.matrix.utils import AddressReachability, make_room_alias
 from transport.message import Message as TransportMessage
-from transport.utils import _RetryQueue
+from transport.utils import MessageQueue
 
 USERID0 = "@Arthur:RestaurantAtTheEndOfTheUniverse"
 USERID1 = "@Alice:Wonderland"
@@ -436,7 +436,7 @@ def test_matrix_message_retry(
     )
     chain_state = raiden_service.wal.state_manager.current_state
 
-    retry_queue: _RetryQueue = transport._get_retrier(partner_address)
+    retry_queue: MessageQueue = transport._get_retrier(partner_address)
     assert bool(retry_queue), "retry_queue not running"
 
     # Send the initial message

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -87,7 +87,7 @@ def mock_matrix(
 
     transport = MatrixTransportNode(raiden_service.address, config)
     transport._raiden_service = raiden_service
-    transport._stop_event.clear()
+    transport.stop_event.clear()
     transport._address_mgr.add_userid_for_address(factories.HOP1, USERID1)
     transport._client.user_id = USERID0
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -445,7 +445,7 @@ def test_matrix_message_retry(
     chain_state.queueids_to_queues[queueid] = [message]
     retry_queue.enqueue(
         queue_identifier=QueueIdentifier(
-            recipient=retry_queue.receiver, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
+            recipient=retry_queue.recipient, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
         ),
         message=message
     )

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -421,7 +421,7 @@ def test_matrix_message_retry(
             "sync_latency": 15_000,
         },
     )
-    transport._send_raw = MagicMock()
+    transport.send_message = MagicMock()
 
     transport.start(raiden_service, raiden_service.message_handler, None)
     transport.log = MagicMock()
@@ -452,7 +452,7 @@ def test_matrix_message_retry(
 
     gevent.sleep(1)
 
-    assert transport._send_raw.call_count == 1
+    assert transport.send_message.call_count == 1
 
     # Receiver goes offline
     transport._address_mgr._address_to_reachability[
@@ -463,7 +463,7 @@ def test_matrix_message_retry(
 
     # now we don't have user presence support so the log will not be there,
     # also the call count should be 2 and 3 at the final result
-    assert transport._send_raw.call_count == 2
+    assert transport.send_message.call_count == 2
 
     # Receiver comes back online
     transport._address_mgr._address_to_reachability[
@@ -473,7 +473,7 @@ def test_matrix_message_retry(
     gevent.sleep(retry_interval)
 
     # Retrier now should have sent the message again
-    assert transport._send_raw.call_count == 3
+    assert transport.send_message.call_count == 3
 
     transport.stop()
     transport.get()
@@ -501,7 +501,7 @@ def test_join_invalid_discovery(
         }
     )
     transport._client.api.retry_timeout = 0
-    transport._send_raw = MagicMock()
+    transport.send_message = MagicMock()
 
     transport.start(raiden_service, raiden_service.message_handler, None)
     transport.log = MagicMock()
@@ -646,7 +646,7 @@ def test_monitoring_global_messages(
         }
     )
     transport._client.api.retry_timeout = 0
-    transport._send_raw = MagicMock()
+    transport.send_message = MagicMock()
     raiden_service = MockRaidenService(None)
     raiden_service.config = dict(services=dict(monitoring_enabled=True))
 
@@ -706,7 +706,7 @@ def test_pfs_global_messages(
         }
     )
     transport._client.api.retry_timeout = 0
-    transport._send_raw = MagicMock()
+    transport.send_message = MagicMock()
     raiden_service = MockRaidenService(None)
     raiden_service.config = dict(services=dict(monitoring_enabled=True))
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -23,7 +23,8 @@ from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, List, Optional, Union
 from transport.matrix.client import Room
 from transport.matrix.node import MatrixNode as MatrixTransportNode
-from transport.matrix.utils import AddressReachability, make_room_alias, _RetryQueue
+from transport.matrix.utils import AddressReachability, make_room_alias
+from transport.utils import _RetryQueue
 from transport.message import Message as TransportMessage
 
 USERID0 = "@Arthur:RestaurantAtTheEndOfTheUniverse"

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -424,7 +424,7 @@ def test_matrix_message_retry(
     transport.send_message = MagicMock()
 
     transport.start(raiden_service, raiden_service.message_handler, None)
-    transport.log = MagicMock()
+    transport._log = MagicMock()
 
     # Receiver is online
     transport._address_mgr._address_to_reachability[
@@ -504,7 +504,7 @@ def test_join_invalid_discovery(
     transport.send_message = MagicMock()
 
     transport.start(raiden_service, raiden_service.message_handler, None)
-    transport.log = MagicMock()
+    transport._log = MagicMock()
     discovery_room_name = make_room_alias(transport.network_id, "discovery")
     assert isinstance(transport._global_rooms.get(discovery_room_name), Room)
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -24,8 +24,8 @@ from raiden.utils.typing import Address, List, Optional, Union
 from transport.matrix.client import Room
 from transport.matrix.node import MatrixNode as MatrixTransportNode
 from transport.matrix.utils import AddressReachability, make_room_alias
-from transport.utils import _RetryQueue
 from transport.message import Message as TransportMessage
+from transport.utils import _RetryQueue
 
 USERID0 = "@Arthur:RestaurantAtTheEndOfTheUniverse"
 USERID1 = "@Alice:Wonderland"

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -122,7 +122,7 @@ def ping_pong_message_success(transport0, transport1):
 
     transport0._raiden_service.sign(ping_message)
     transport1._raiden_service.sign(pong_message)
-    transport0.send_message(
+    transport0.enqueue_message(
         *TransportMessage.wrap(queueid1, ping_message)
     )
 
@@ -138,7 +138,7 @@ def ping_pong_message_success(transport0, transport1):
 
     transport0._raiden_service.sign(pong_message)
     transport1._raiden_service.sign(ping_message)
-    transport1.send_message(
+    transport1.enqueue_message(
         *TransportMessage.wrap(queueid0, ping_message)
     )
 
@@ -323,7 +323,7 @@ def test_matrix_message_sync(matrix_transports):
     for i in range(5):
         message = Processed(message_identifier=i)
         transport0._raiden_service.sign(message)
-        transport0.send_message(
+        transport0.enqueue_message(
             *TransportMessage.wrap(queue_identifier, message)
         )
 
@@ -344,7 +344,7 @@ def test_matrix_message_sync(matrix_transports):
     for i in range(10, 15):
         message = Processed(message_identifier=i)
         transport0._raiden_service.sign(message)
-        transport0.send_message(
+        transport0.enqueue_message(
             *TransportMessage.wrap(queue_identifier, message)
         )
 

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -114,7 +114,7 @@ def run_test_regression_transport_global_queues_are_initialized_on_restart_for_s
 
     transport = MatrixTransportNode(app0.config["transport"]["matrix"])
     transport.send_async = Mock()
-    transport._send_raw = Mock()
+    transport.send_message = Mock()
 
     old_start_transport = transport.start
 
@@ -126,7 +126,7 @@ def run_test_regression_transport_global_queues_are_initialized_on_restart_for_s
         assert len(transport._global_send_queue) == 2
         # No other messages were sent at this point
         transport.send_async.assert_not_called()
-        transport._send_raw.assert_not_called()
+        transport.send_message.assert_not_called()
         old_start_transport(*args, **kwargs)
 
     transport.start = start_transport

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -16,8 +16,8 @@ class Runnable:
 
     def __init__(self) -> None:
         self._set_greenlet()
-        self._stop_event = Event()
-        self._stop_event.set()
+        self.stop_event = Event()
+        self.stop_event.set()
 
     def start(self) -> None:
         """ Synchronously start task

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any
 
 import structlog
 from gevent import Greenlet

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import structlog
 from gevent import Greenlet
+from gevent.event import Event
 
 log = structlog.get_logger(__name__)
 
@@ -15,6 +16,8 @@ class Runnable:
 
     def __init__(self) -> None:
         self._set_greenlet()
+        self._stop_event = Event()
+        self._stop_event.set()
 
     def start(self) -> None:
         """ Synchronously start task

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -13,13 +13,7 @@ class Runnable:
     In the future, when proper restart is implemented, may be replaced by actual greenlet
     """
 
-    args: Sequence = tuple()  # args for _run()
-    kwargs: dict = dict()  # kwargs for _run()
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.args = args
-        self.kwargs = kwargs
-
+    def __init__(self) -> None:
         self._set_greenlet()
 
     def start(self) -> None:
@@ -30,17 +24,12 @@ class Runnable:
         """
         if self.greenlet:
             raise RuntimeError(f"Greenlet {self.greenlet!r} already started")
-        pristine = (
-            not self.greenlet.dead
-            and tuple(self.greenlet.args) == tuple(self.args)
-            and self.greenlet.kwargs == self.kwargs
-        )
-        if not pristine:
+        if self.greenlet.dead:
             self._set_greenlet()
         self.greenlet.start()
 
     def _set_greenlet(self):
-        self.greenlet = Greenlet(self._run, *self.args, **self.kwargs)
+        self.greenlet = Greenlet(self._run)
         self.greenlet.name = f"{self.__class__.__name__}|{self.greenlet.name}"
 
     def _run(self, *args: Any, **kwargs: Any) -> None:

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -79,9 +79,6 @@ class MatrixNode(TransportNode, Runnable):
 
         self._started = False
 
-        self._stop_event = Event()
-        self._stop_event.set()
-
         self._global_send_event = Event()
         self._prioritize_global_messages = True
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -660,16 +660,16 @@ class MatrixNode(TransportNode):
         retrier = self._get_retrier(queue_identifier.recipient)
         retrier.enqueue(queue_identifier=queue_identifier, message=message)
 
-    def send_message(self, receiver_address: Address, message_data: str):
+    def send_message(self, message_data: str, recipient: Address):
         with self._getroom_lock:
-            room = self._get_room_for_address(receiver_address)
+            room = self._get_room_for_address(recipient)
         if not room:
             self.log.error(
-                "No room for receiver", receiver=to_normalized_address(receiver_address)
+                "No room for receiver", receiver=to_normalized_address(recipient)
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(receiver_address), room=room, data=message_data.replace("\n", "\\n")
+            "Send raw", receiver=pex(recipient), room=room, data=message_data.replace("\n", "\\n")
         )
         print("---->> Matrix Send Message " + message_data)
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -40,7 +40,7 @@ log = structlog.get_logger(__name__)
 class MatrixNode(TransportNode):
     _room_prefix = "raiden"
     _room_sep = "_"
-    log = log
+    _log = log
 
     def __init__(self, address: Address, config: dict):
         TransportNode.__init__(self, address)
@@ -102,14 +102,17 @@ class MatrixNode(TransportNode):
         if self._prioritize_global_messages:
             self._global_send_queue.join()
 
+    @property
     def raiden_service(self) -> 'RaidenService':
         return self._raiden_service
 
+    @property
     def config(self) -> {}:
         return self._config
 
+    @property
     def log(self):
-        return self.log
+        return self._log
 
     def start_greenlet_for_light_client(self):
         Runnable.start(self)
@@ -145,7 +148,7 @@ class MatrixNode(TransportNode):
             prev_access_token=prev_access_token
         )
 
-        self.log = log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))
+        self._log = log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))
 
         self.log.debug("Start: handle thread", handle_thread=self._client._handle_thread)
         if self._client._handle_thread:
@@ -1173,7 +1176,7 @@ class MatrixLightClientNode(MatrixNode):
             light_client_address=self.address
         )
 
-        self.log = log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))
+        self._log = log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))
 
         self.log.debug("Start: handle thread", handle_thread=self._client._handle_thread)
         if self._client._handle_thread:

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -667,7 +667,7 @@ class MatrixNode(TransportNode):
         retrier = self._get_retrier(queue_identifier.recipient)
         retrier.enqueue(queue_identifier=queue_identifier, message=message)
 
-    def send_message(self, message_data: str, recipient: Address):
+    def send_message(self, payload: str, recipient: Address):
         with self._getroom_lock:
             room = self._get_room_for_address(recipient)
         if not room:
@@ -676,11 +676,11 @@ class MatrixNode(TransportNode):
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(recipient), room=room, data=message_data.replace("\n", "\\n")
+            "Send raw", receiver=pex(recipient), room=room, data=payload.replace("\n", "\\n")
         )
-        print("---->> Matrix Send Message " + message_data)
+        print("---->> Matrix Send Message " + payload)
 
-        room.send_text(message_data)
+        room.send_text(payload)
 
     def _get_room_for_address(self, address: Address, allow_missing_peers=False) -> Optional[Room]:
         if self.stop_event.ready():
@@ -1232,20 +1232,20 @@ class MatrixLightClientNode(MatrixNode):
             self.stop()  # ensure cleanup and wait on subtasks
             raise
 
-    def send_message(self, receiver_address: Address, data: str):
+    def send_message(self, payload: str, recipient: Address):
         with self._getroom_lock:
-            room = self._get_room_for_address(receiver_address)
+            room = self._get_room_for_address(recipient)
         if not room:
             self.log.error(
-                "No room for receiver", receiver=to_normalized_address(receiver_address)
+                "No room for receiver", receiver=to_normalized_address(recipient)
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(receiver_address), room=room, data=data.replace("\n", "\\n")
+            "Send raw", receiver=pex(recipient), room=room, data=payload.replace("\n", "\\n")
         )
-        print("---- Matrix Send Message " + data)
+        print("---- Matrix Send Message " + payload)
 
-        room.send_text(data)
+        room.send_text(payload)
 
     def _get_room_for_address(self, address: Address, allow_missing_peers=False) -> Optional[Room]:
         if self.stop_event.ready():

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -647,7 +647,7 @@ class MatrixNode(TransportNode, Runnable):
     def _get_retrier(self, receiver: Address) -> _RetryQueue:
         """ Construct and return a _RetryQueue for receiver """
         if receiver not in self._address_to_retrier:
-            retrier = _RetryQueue(transport=self, receiver=receiver)
+            retrier = _RetryQueue(transport_node=self, receiver=receiver)
             self._address_to_retrier[receiver] = retrier
             # Always start the _RetryQueue, otherwise `stop` will block forever
             # waiting for the corresponding gevent.Greenlet to complete. This

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -284,7 +284,7 @@ class MatrixNode(TransportNode):
             # representing the target node
             self._address_mgr.refresh_address_presence(node_address)
 
-    def send_message(self, message: TransportMessage, recipient: Address):
+    def enqueue_message(self, message: TransportMessage, recipient: Address):
         """Queue the message for sending to recipient in the queue_identifier
 
         It may be called before transport is started, to initialize message queues
@@ -299,7 +299,7 @@ class MatrixNode(TransportNode):
         # These are not protocol messages, but transport specific messages
         if isinstance(raiden_message, (Ping, Pong)):
             raise ValueError(
-                "Do not use send_message for {} messages".format(raiden_message.__class__.__name__)
+                "Do not use enqueue_message for {} messages".format(raiden_message.__class__.__name__)
             )
 
         self.log.info(
@@ -632,7 +632,7 @@ class MatrixNode(TransportNode):
             queue_identifier = QueueIdentifier(
                 recipient=message.sender, channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE
             )
-            self.send_message(*TransportMessage.wrap(queue_identifier, delivered_message))
+            self.enqueue_message(*TransportMessage.wrap(queue_identifier, delivered_message))
             self._raiden_service.on_message(message)
 
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -28,7 +28,8 @@ from raiden.utils.typing import ChainID, AddressHex
 from transport.matrix.client import Room, GMatrixClient
 from transport.matrix.utils import get_available_servers_from_config, make_client, get_server_url, UserAddressManager, \
     login_or_register, make_room_alias, join_global_room, UserPresence, validate_userid_signature, JOIN_RETRIES, \
-    AddressReachability, validate_and_parse_message, login_or_register_light_client, _RetryQueue
+    AddressReachability, validate_and_parse_message, login_or_register_light_client
+from transport.utils import _RetryQueue
 from transport.message import Message as TransportMessage
 from transport.node import Node as TransportNode
 from transport.udp import utils as udp_utils

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -29,10 +29,10 @@ from transport.matrix.client import Room, GMatrixClient
 from transport.matrix.utils import get_available_servers_from_config, make_client, get_server_url, UserAddressManager, \
     login_or_register, make_room_alias, join_global_room, UserPresence, validate_userid_signature, JOIN_RETRIES, \
     AddressReachability, validate_and_parse_message, login_or_register_light_client
-from transport.utils import _RetryQueue
 from transport.message import Message as TransportMessage
 from transport.node import Node as TransportNode
 from transport.udp import utils as udp_utils
+from transport.utils import _RetryQueue
 
 _RoomID = NewType("_RoomID", str)
 log = structlog.get_logger(__name__)

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -660,7 +660,7 @@ class MatrixNode(TransportNode):
         retrier = self._get_retrier(queue_identifier.recipient)
         retrier.enqueue(queue_identifier=queue_identifier, message=message)
 
-    def _send_raw(self, receiver_address: Address, data: str):
+    def send_message(self, receiver_address: Address, message_data: str):
         with self._getroom_lock:
             room = self._get_room_for_address(receiver_address)
         if not room:
@@ -669,11 +669,11 @@ class MatrixNode(TransportNode):
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(receiver_address), room=room, data=data.replace("\n", "\\n")
+            "Send raw", receiver=pex(receiver_address), room=room, data=message_data.replace("\n", "\\n")
         )
-        print("---->> Matrix Send Message " + data)
+        print("---->> Matrix Send Message " + message_data)
 
-        room.send_text(data)
+        room.send_text(message_data)
 
     def _get_room_for_address(self, address: Address, allow_missing_peers=False) -> Optional[Room]:
         if self._stop_event.ready():
@@ -1225,7 +1225,7 @@ class MatrixLightClientNode(MatrixNode):
             self.stop()  # ensure cleanup and wait on subtasks
             raise
 
-    def _send_raw(self, receiver_address: Address, data: str):
+    def send_message(self, receiver_address: Address, data: str):
         with self._getroom_lock:
             room = self._get_room_for_address(receiver_address)
         if not room:

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -98,6 +98,10 @@ class MatrixNode(TransportNode):
 
         self._message_handler: Optional[MessageHandler] = None
 
+    def enqueue_global_messages(self):
+        if self._prioritize_global_messages:
+            self._global_send_queue.join()
+
     def raiden_service(self) -> 'RaidenService':
         return self._raiden_service
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -16,10 +16,9 @@ from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddres
 from raiden.message_handler import MessageHandler
 from raiden.messages import Message, Ping, Pong, SignedRetrieableMessage, SignedMessage, Delivered, Processed, ToDevice
 from raiden.raiden_service import RaidenService
-from raiden.transfer import views
 from raiden.transfer.identifiers import QueueIdentifier
 from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_QUEUE
-from raiden.transfer.state import QueueIdsToQueues, NODE_NETWORK_REACHABLE, NODE_NETWORK_UNKNOWN, \
+from raiden.transfer.state import NODE_NETWORK_REACHABLE, NODE_NETWORK_UNKNOWN, \
     NODE_NETWORK_UNREACHABLE
 from raiden.transfer.state_change import ActionUpdateTransportAuthData, ActionChangeNodeNetworkState
 from raiden.utils import Address, pex
@@ -367,11 +366,6 @@ class MatrixNode(TransportNode, Runnable):
             # Stop prioritizing global messages after initial queue has been emptied
             self._prioritize_global_messages = False
             self._global_send_event.wait(self._config["retry_interval"])
-
-    @property
-    def _queueids_to_queues(self) -> QueueIdsToQueues:
-        chain_state = views.state_from_raiden(self._raiden_service)
-        return views.get_all_messagequeues(chain_state)
 
     @property
     def _user_id(self) -> Optional[str]:

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -651,17 +651,17 @@ class MatrixNode(TransportNode):
             "ToDevice message received", sender=pex(to_device.sender), message=to_device
         )
 
-    def _get_retrier(self, receiver: Address) -> _RetryQueue:
-        """ Construct and return a _RetryQueue for receiver """
-        if receiver not in self._address_to_retrier:
-            retrier = _RetryQueue(transport_node=self, receiver=receiver)
-            self._address_to_retrier[receiver] = retrier
+    def _get_retrier(self, recipient: Address) -> _RetryQueue:
+        """ Construct and return a _RetryQueue for recipient """
+        if recipient not in self._address_to_retrier:
+            retrier = _RetryQueue(transport_node=self, recipient=recipient)
+            self._address_to_retrier[recipient] = retrier
             # Always start the _RetryQueue, otherwise `stop` will block forever
             # waiting for the corresponding gevent.Greenlet to complete. This
             # has no negative side-effects if the transport has stopped because
             # the retrier itself checks the transport running state.
             retrier.start()
-        return self._address_to_retrier[receiver]
+        return self._address_to_retrier[recipient]
 
     def _send_with_retry(self, queue_identifier: QueueIdentifier, message: Message):
         retrier = self._get_retrier(queue_identifier.recipient)

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -672,11 +672,11 @@ class MatrixNode(TransportNode):
             room = self._get_room_for_address(recipient)
         if not room:
             self.log.error(
-                "No room for receiver", receiver=to_normalized_address(recipient)
+                "No room for recipient", recipient=to_normalized_address(recipient)
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(recipient), room=room, data=payload.replace("\n", "\\n")
+            "Send raw", recipient=pex(recipient), room=room, payload=payload.replace("\n", "\\n")
         )
         print("---->> Matrix Send Message " + payload)
 
@@ -1237,11 +1237,11 @@ class MatrixLightClientNode(MatrixNode):
             room = self._get_room_for_address(recipient)
         if not room:
             self.log.error(
-                "No room for receiver", receiver=to_normalized_address(recipient)
+                "No room for recipient", recipient=to_normalized_address(recipient)
             )
             return
         self.log.debug(
-            "Send raw", receiver=pex(recipient), room=room, data=payload.replace("\n", "\\n")
+            "Send raw", recipient=pex(recipient), room=room, payload=payload.replace("\n", "\\n")
         )
         print("---- Matrix Send Message " + payload)
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -652,7 +652,7 @@ class MatrixNode(TransportNode):
         )
 
     def _get_retrier(self, recipient: Address) -> MessageQueue:
-        """ Construct and return a _RetryQueue for recipient """
+        """ Construct and return a MessageQueue for recipient """
         if recipient not in self._address_to_retrier:
             retrier = MessageQueue(transport_node=self, recipient=recipient)
             self._address_to_retrier[recipient] = retrier

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -37,14 +37,14 @@ _RoomID = NewType("_RoomID", str)
 log = structlog.get_logger(__name__)
 
 
-class MatrixNode(TransportNode, Runnable):
+class MatrixNode(TransportNode):
     _room_prefix = "raiden"
     _room_sep = "_"
     log = log
 
     def __init__(self, address: Address, config: dict):
         TransportNode.__init__(self, address)
-        Runnable.__init__(self)
+
         self._config = config
         self._raiden_service: Optional[RaidenService] = None
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -99,6 +99,15 @@ class MatrixNode(TransportNode, Runnable):
 
         self._message_handler: Optional[MessageHandler] = None
 
+    def raiden_service(self) -> 'RaidenService':
+        return self._raiden_service
+
+    def config(self) -> {}:
+        return self._config
+
+    def log(self):
+        return self.log
+
     def start_greenlet_for_light_client(self):
         Runnable.start(self)
 

--- a/transport/matrix/utils.py
+++ b/transport/matrix/utils.py
@@ -1,6 +1,5 @@
 import json
 import re
-import time
 from binascii import Error as DecodeError
 from collections import defaultdict
 from enum import Enum
@@ -17,8 +16,6 @@ from typing import (
     Set,
     Tuple,
     Union,
-    NamedTuple,
-    Iterator,
 )
 from urllib.parse import urlparse
 
@@ -36,20 +33,13 @@ from raiden.messages import (
     SignedMessage,
     decode as message_from_bytes,
     from_dict as message_from_dict,
-    RetrieableMessage,
-    Delivered,
-    Ping,
-    Pong,
 )
 from raiden.network.utils import get_http_rtt
-from raiden.transfer.identifiers import QueueIdentifier
 from raiden.utils import pex
-from raiden.utils.runnable import Runnable
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import Address, ChainID, Signature
 from raiden_contracts.constants import ID_TO_NETWORKNAME
 from transport.matrix.client import GMatrixClient, Room, User
-from transport.udp import utils as udp_utils
 
 log = structlog.get_logger(__name__)
 
@@ -62,176 +52,6 @@ ROOM_NAME_PREFIX = "raiden"
 HTTP_PREFIX = "http"
 HTTPS_PREFIX = "https"
 URL_STARTER_PREFIX = "://"
-
-
-class _RetryQueue(Runnable):
-    """ A helper Runnable to send batched messages to receiver through transport """
-
-    class _MessageData(NamedTuple):
-        """ Small helper data structure for message queue """
-
-        queue_identifier: QueueIdentifier
-        message: Message
-        text: str
-        # generator that tells if the message should be sent now
-        expiration_generator: Iterator[bool]
-
-    def __init__(self, transport: "MatrixNode", receiver: Address):
-        self.transport = transport
-        self.receiver = receiver
-        self._message_queue: List[_RetryQueue._MessageData] = list()
-        self._notify_event = gevent.event.Event()
-        self._lock = gevent.lock.Semaphore()
-        super().__init__()
-        self.greenlet.name = f"RetryQueue " f"recipient:{pex(self.receiver)}"
-
-    @property
-    def log(self):
-        return self.transport.log
-
-    @staticmethod
-    def _expiration_generator(
-        timeout_generator: Iterable[float], now: Callable[[], float] = time.time
-    ) -> Iterator[bool]:
-        """Stateful generator that yields True if more than timeout has passed since previous True,
-        False otherwise.
-
-        Helper method to tell when a message needs to be retried (more than timeout seconds
-        passed since last time it was sent).
-        timeout is iteratively fetched from timeout_generator
-        First value is True to always send message at least once
-        """
-        for timeout in timeout_generator:
-            _next = now() + timeout  # next value is now + next generated timeout
-            yield True
-            while now() < _next:  # yield False while next is still in the future
-                yield False
-
-    def enqueue(self, queue_identifier: QueueIdentifier, message: Message):
-        """ Enqueue a message to be sent, and notify main loop """
-        assert queue_identifier.recipient == self.receiver
-        with self._lock:
-            already_queued = any(
-                queue_identifier == data.queue_identifier and message == data.message
-                for data in self._message_queue
-            )
-            if already_queued:
-                self.log.warning(
-                    "Message already in queue - ignoring",
-                    receiver=pex(self.receiver),
-                    queue=queue_identifier,
-                    message=message,
-                )
-                return
-            timeout_generator = udp_utils.timeout_exponential_backoff(
-                self.transport._config["retries_before_backoff"],
-                self.transport._config["retry_interval"],
-                self.transport._config["retry_interval"] * 10,
-            )
-            expiration_generator = self._expiration_generator(timeout_generator)
-            self._message_queue.append(
-                _RetryQueue._MessageData(
-                    queue_identifier=queue_identifier,
-                    message=message,
-                    text=json.dumps(message.to_dict()),
-                    expiration_generator=expiration_generator,
-                )
-            )
-        self.notify()
-
-    def notify(self):
-        """ Notify main loop to check if anything needs to be sent """
-        with self._lock:
-            self._notify_event.set()
-
-    def _check_and_send(self):
-        """Check and send all pending/queued messages that are not waiting on retry timeout
-
-        After composing the to-be-sent message, also message queue from messages that are not
-        present in the respective SendMessageEvent queue anymore
-        """
-        if not self.transport.greenlet:
-            self.log.warning("Can't retry", reason="Transport not yet started")
-            return
-        if self.transport._stop_event.ready():
-            self.log.warning("Can't retry", reason="Transport stopped")
-            return
-
-        if self.transport._prioritize_global_messages:
-            # During startup global messages have to be sent first
-            self.transport._global_send_queue.join()
-
-        self.log.debug("Retrying message", receiver=to_normalized_address(self.receiver))
-
-        message_texts = [
-            data.text
-            for data in self._message_queue
-            # if expired_gen generator yields False, message was sent recently, so skip it
-            if next(data.expiration_generator)
-        ]
-
-        def message_is_in_queue(data: _RetryQueue._MessageData) -> bool:
-            return any(
-                isinstance(data.message, RetrieableMessage)
-                and send_event.message_identifier == data.message.message_identifier
-                for send_event in self.transport._queueids_to_queues[data.queue_identifier]
-            )
-
-        # clean after composing, so any queued messages (e.g. Delivered) are sent at least once
-        for msg_data in self._message_queue[:]:
-            remove = False
-            if isinstance(msg_data.message, (Delivered, Ping, Pong)):
-                # e.g. Delivered, send only once and then clear
-                # TODO: Is this correct? Will a missed Delivered be 'fixed' by the
-                #       later `Processed` message?
-                remove = True
-            elif msg_data.queue_identifier not in self.transport._queueids_to_queues:
-                remove = True
-                self.log.debug(
-                    "Stopping message send retry",
-                    queue=msg_data.queue_identifier,
-                    message=msg_data.message,
-                    reason="Raiden queue is gone",
-                )
-            elif not message_is_in_queue(msg_data):
-                remove = True
-                self.log.debug(
-                    "Stopping message send retry",
-                    queue=msg_data.queue_identifier,
-                    message=msg_data.message,
-                    reason="Message was removed from queue",
-                )
-
-            if remove:
-                self._message_queue.remove(msg_data)
-
-        if message_texts:
-            self.log.debug("Send", receiver=pex(self.receiver), messages=message_texts)
-            self.transport._send_raw(self.receiver, "\n".join(message_texts))
-
-    def _run(self):
-        msg = f"_RetryQueue started before transport._raiden_service is set"
-        assert self.transport._raiden_service is not None, msg
-        self.greenlet.name = (
-            f"RetryQueue "
-            f"node:{pex(self.transport._raiden_service.address)} "
-            f"recipient:{pex(self.receiver)}"
-        )
-        # run while transport parent is running
-        while not self.transport._stop_event.ready():
-            # once entered the critical section, block any other enqueue or notify attempt
-            with self._lock:
-                self._notify_event.clear()
-                if self._message_queue:
-                    self._check_and_send()
-            # wait up to retry_interval (or to be notified) before checking again
-            self._notify_event.wait(self.transport._config["retry_interval"])
-
-    def __str__(self):
-        return self.greenlet.name
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} for {to_normalized_address(self.receiver)}>"
 
 
 class UserPresence(Enum):

--- a/transport/node.py
+++ b/transport/node.py
@@ -53,9 +53,9 @@ class Node(ABC, Runnable):
         """
 
     @abstractmethod
-    def send_message(self, recipient: Address, message_data: str):
+    def send_message(self, payload: str, recipient: Address):
         """
-        Send a message to the recipient.
+        Send a message payload to the recipient.
         Due to a coupled design, this method should only be called by the _RetryQueue class.
         Other entities should use enqueue_message instead.
         """

--- a/transport/node.py
+++ b/transport/node.py
@@ -45,6 +45,14 @@ class Node(ABC, Runnable):
         """
 
     @abstractmethod
+    def send_message(self, recipient: Address, message_data: str):
+        """
+        Send a message to the recipient.
+        Due to a coupled design, this method should only be called by the _RetryQueue class.
+        Other entities should use enqueue_message instead.
+        """
+
+    @abstractmethod
     def start_health_check(self, address: Address):
         """
         Start health-check (status monitoring) for a peer.

--- a/transport/node.py
+++ b/transport/node.py
@@ -18,7 +18,7 @@ class Node(ABC, Runnable):
     def __init__(self, address: Address):
         """
         The address represented by the Node in the context of communications.
-        Messages to be received by this Node should be have this address as the message receiver.
+        Messages to be received by this Node should be have this address as the message recipient.
         Messages to be sent from this Node should have this address as the message sender.
         """
         Runnable.__init__(self)

--- a/transport/node.py
+++ b/transport/node.py
@@ -45,6 +45,14 @@ class Node(ABC, Runnable):
         """
 
     @abstractmethod
+    def enqueue_global_messages(self):
+        """
+        Enqueue global messages to be sent.
+        This method might be implemented as a no-op if the concept of global messages does not apply
+        to a specific transport layer implementation.
+        """
+
+    @abstractmethod
     def send_message(self, recipient: Address, message_data: str):
         """
         Send a message to the recipient.

--- a/transport/node.py
+++ b/transport/node.py
@@ -3,9 +3,10 @@ from typing import Any
 
 from raiden.messages import Message
 from raiden.utils import Address
+from raiden.utils.runnable import Runnable
 
 
-class Node(ABC):
+class Node(ABC, Runnable):
     """
     Node is an abstraction that represents a single address (belonging to regular node or one registered as a light
     client) managed by the transport layer of the running Lumino node.
@@ -20,6 +21,7 @@ class Node(ABC):
         Messages to be received by this Node should be have this address as the message receiver.
         Messages to be sent from this Node should have this address as the message sender.
         """
+        Runnable.__init__(self)
         self.address = address
 
     @abstractmethod

--- a/transport/node.py
+++ b/transport/node.py
@@ -39,7 +39,7 @@ class Node(ABC, Runnable):
     @abstractmethod
     def enqueue_message(self, message: Message, recipient: Address):
         """
-        Enqueue a message to be sent the recipient.
+        Enqueue a message to be sent to the recipient.
         This method may be called before the transport node is started, but the actual message sending
         should only be attempted when the transport node is started.
         """

--- a/transport/node.py
+++ b/transport/node.py
@@ -67,3 +67,24 @@ class Node(ABC):
         """
         Wait until the transport node finishes its pending tasks or the given timeout passes.
         """
+
+    @property
+    @abstractmethod
+    def raiden_service(self) -> 'RaidenService':
+        """
+        Return the Raiden Service object for this entity.
+        """
+
+    @property
+    @abstractmethod
+    def config(self) -> {}:
+        """
+        Return the config dictionary for this entity.
+        """
+
+    @property
+    @abstractmethod
+    def log(self):
+        """
+        Return the logger for this entity.
+        """

--- a/transport/node.py
+++ b/transport/node.py
@@ -37,9 +37,9 @@ class Node(ABC, Runnable):
         """
 
     @abstractmethod
-    def send_message(self, message: Message, recipient: Address):
+    def enqueue_message(self, message: Message, recipient: Address):
         """
-        Send a message to the recipient.
+        Enqueue a message to be sent the recipient.
         This method may be called before the transport node is started, but the actual message sending
         should only be attempted when the transport node is started.
         """

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -30,6 +30,12 @@ class RifCommsNode(TransportNode):
     def enqueue_message(self, message: Message, recipient: Address):
         raise NotImplementedError
 
+    def enqueue_global_messages(self):
+        raise NotImplementedError
+
+    def send_message(self, recipient: Address, message_data: str):
+        raise NotImplementedError
+
     def start_health_check(self, address: Address):
         raise NotImplementedError
 
@@ -40,6 +46,15 @@ class RifCommsNode(TransportNode):
         raise NotImplementedError
 
     def join(self, timeout=None):
+        raise NotImplementedError
+
+    def raiden_service(self) -> 'RaidenService':
+        raise NotImplementedError
+
+    def config(self) -> {}:
+        raise NotImplementedError
+
+    def log(self):
         raise NotImplementedError
 
     def _run(self, *args: Any, **kwargs: Any) -> None:

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -3,17 +3,15 @@ from typing import Any
 from raiden.message_handler import MessageHandler
 from raiden.messages import Message
 from raiden.raiden_service import RaidenService
-from raiden.utils.runnable import Runnable
 from raiden.utils.typing import Address
 from transport.node import Node as TransportNode
 from transport.rif_comms.client import RifCommsClient
 
 
-class RifCommsNode(TransportNode, Runnable):
+class RifCommsNode(TransportNode):
 
     def __init__(self, address: Address, config: dict):
         TransportNode.__init__(self, address)
-        Runnable.__init__(self)
         self._config = config
 
         self._client = RifCommsClient("0x5Ec92458ACD047f3B583E09C243a480Ef54A68D4", self._config["grpc_endpoint"])

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -27,7 +27,7 @@ class RifCommsNode(TransportNode):
     def stop(self):
         raise NotImplementedError
 
-    def send_message(self, message: Message, recipient: Address):
+    def enqueue_message(self, message: Message, recipient: Address):
         raise NotImplementedError
 
     def start_health_check(self, address: Address):

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -48,12 +48,15 @@ class RifCommsNode(TransportNode):
     def join(self, timeout=None):
         raise NotImplementedError
 
+    @property
     def raiden_service(self) -> 'RaidenService':
         raise NotImplementedError
 
+    @property
     def config(self) -> {}:
         raise NotImplementedError
 
+    @property
     def log(self):
         raise NotImplementedError
 

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -33,7 +33,7 @@ class RifCommsNode(TransportNode):
     def enqueue_global_messages(self):
         raise NotImplementedError
 
-    def send_message(self, recipient: Address, message_data: str):
+    def send_message(self, payload: str, recipient: Address):
         raise NotImplementedError
 
     def start_health_check(self, address: Address):

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -1,0 +1,181 @@
+import json
+import time
+from typing import NamedTuple, Iterator, List, Iterable, Callable
+
+import gevent
+from eth_utils import to_normalized_address
+from raiden.messages import Message, RetrieableMessage, Delivered, Ping, Pong
+from raiden.transfer.identifiers import QueueIdentifier
+from raiden.utils import Address, pex
+from raiden.utils.runnable import Runnable
+from transport.udp import utils as udp_utils
+
+
+class _RetryQueue(Runnable):
+    """ A helper Runnable to send batched messages to receiver through transport """
+
+    class _MessageData(NamedTuple):
+        """ Small helper data structure for message queue """
+
+        queue_identifier: QueueIdentifier
+        message: Message
+        text: str
+        # generator that tells if the message should be sent now
+        expiration_generator: Iterator[bool]
+
+    def __init__(self, transport: "MatrixNode", receiver: Address):
+        self.transport = transport
+        self.receiver = receiver
+        self._message_queue: List[_RetryQueue._MessageData] = list()
+        self._notify_event = gevent.event.Event()
+        self._lock = gevent.lock.Semaphore()
+        super().__init__()
+        self.greenlet.name = f"RetryQueue " f"recipient:{pex(self.receiver)}"
+
+    @property
+    def log(self):
+        return self.transport.log
+
+    @staticmethod
+    def _expiration_generator(
+        timeout_generator: Iterable[float], now: Callable[[], float] = time.time
+    ) -> Iterator[bool]:
+        """Stateful generator that yields True if more than timeout has passed since previous True,
+        False otherwise.
+
+        Helper method to tell when a message needs to be retried (more than timeout seconds
+        passed since last time it was sent).
+        timeout is iteratively fetched from timeout_generator
+        First value is True to always send message at least once
+        """
+        for timeout in timeout_generator:
+            _next = now() + timeout  # next value is now + next generated timeout
+            yield True
+            while now() < _next:  # yield False while next is still in the future
+                yield False
+
+    def enqueue(self, queue_identifier: QueueIdentifier, message: Message):
+        """ Enqueue a message to be sent, and notify main loop """
+        assert queue_identifier.recipient == self.receiver
+        with self._lock:
+            already_queued = any(
+                queue_identifier == data.queue_identifier and message == data.message
+                for data in self._message_queue
+            )
+            if already_queued:
+                self.log.warning(
+                    "Message already in queue - ignoring",
+                    receiver=pex(self.receiver),
+                    queue=queue_identifier,
+                    message=message,
+                )
+                return
+            timeout_generator = udp_utils.timeout_exponential_backoff(
+                self.transport._config["retries_before_backoff"],
+                self.transport._config["retry_interval"],
+                self.transport._config["retry_interval"] * 10,
+            )
+            expiration_generator = self._expiration_generator(timeout_generator)
+            self._message_queue.append(
+                _RetryQueue._MessageData(
+                    queue_identifier=queue_identifier,
+                    message=message,
+                    text=json.dumps(message.to_dict()),
+                    expiration_generator=expiration_generator,
+                )
+            )
+        self.notify()
+
+    def notify(self):
+        """ Notify main loop to check if anything needs to be sent """
+        with self._lock:
+            self._notify_event.set()
+
+    def _check_and_send(self):
+        """Check and send all pending/queued messages that are not waiting on retry timeout
+
+        After composing the to-be-sent message, also message queue from messages that are not
+        present in the respective SendMessageEvent queue anymore
+        """
+        if not self.transport.greenlet:
+            self.log.warning("Can't retry", reason="Transport not yet started")
+            return
+        if self.transport._stop_event.ready():
+            self.log.warning("Can't retry", reason="Transport stopped")
+            return
+
+        if self.transport._prioritize_global_messages:
+            # During startup global messages have to be sent first
+            self.transport._global_send_queue.join()
+
+        self.log.debug("Retrying message", receiver=to_normalized_address(self.receiver))
+
+        message_texts = [
+            data.text
+            for data in self._message_queue
+            # if expired_gen generator yields False, message was sent recently, so skip it
+            if next(data.expiration_generator)
+        ]
+
+        def message_is_in_queue(data: _RetryQueue._MessageData) -> bool:
+            return any(
+                isinstance(data.message, RetrieableMessage)
+                and send_event.message_identifier == data.message.message_identifier
+                for send_event in self.transport._queueids_to_queues[data.queue_identifier]
+            )
+
+        # clean after composing, so any queued messages (e.g. Delivered) are sent at least once
+        for msg_data in self._message_queue[:]:
+            remove = False
+            if isinstance(msg_data.message, (Delivered, Ping, Pong)):
+                # e.g. Delivered, send only once and then clear
+                # TODO: Is this correct? Will a missed Delivered be 'fixed' by the
+                #       later `Processed` message?
+                remove = True
+            elif msg_data.queue_identifier not in self.transport._queueids_to_queues:
+                remove = True
+                self.log.debug(
+                    "Stopping message send retry",
+                    queue=msg_data.queue_identifier,
+                    message=msg_data.message,
+                    reason="Raiden queue is gone",
+                )
+            elif not message_is_in_queue(msg_data):
+                remove = True
+                self.log.debug(
+                    "Stopping message send retry",
+                    queue=msg_data.queue_identifier,
+                    message=msg_data.message,
+                    reason="Message was removed from queue",
+                )
+
+            if remove:
+                self._message_queue.remove(msg_data)
+
+        if message_texts:
+            self.log.debug("Send", receiver=pex(self.receiver), messages=message_texts)
+            self.transport._send_raw(self.receiver, "\n".join(message_texts))
+
+    def _run(self):
+        msg = f"_RetryQueue started before transport._raiden_service is set"
+        assert self.transport._raiden_service is not None, msg
+        self.greenlet.name = (
+            f"RetryQueue "
+            f"node:{pex(self.transport._raiden_service.address)} "
+            f"recipient:{pex(self.receiver)}"
+        )
+        # run while transport parent is running
+        while not self.transport._stop_event.ready():
+            # once entered the critical section, block any other enqueue or notify attempt
+            with self._lock:
+                self._notify_event.clear()
+                if self._message_queue:
+                    self._check_and_send()
+            # wait up to retry_interval (or to be notified) before checking again
+            self._notify_event.wait(self.transport._config["retry_interval"])
+
+    def __str__(self):
+        return self.greenlet.name
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} for {to_normalized_address(self.receiver)}>"

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -14,7 +14,7 @@ from transport.node import Node as TransportNode
 from transport.udp import utils as udp_utils
 
 
-class _RetryQueue(Runnable):
+class MessageQueue(Runnable):
     """ A helper Runnable to send batched messages to recipient through transport """
 
     class _MessageData(NamedTuple):
@@ -29,7 +29,7 @@ class _RetryQueue(Runnable):
     def __init__(self, transport_node: TransportNode, recipient: Address):
         self.transport_node = transport_node
         self.recipient = recipient
-        self._message_queue: List[_RetryQueue._MessageData] = list()
+        self._message_queue: List[MessageQueue._MessageData] = list()
         self._notify_event = gevent.event.Event()
         self._lock = gevent.lock.Semaphore()
         super().__init__()
@@ -80,7 +80,7 @@ class _RetryQueue(Runnable):
             )
             expiration_generator = self._expiration_generator(timeout_generator)
             self._message_queue.append(
-                _RetryQueue._MessageData(
+                MessageQueue._MessageData(
                     queue_identifier=queue_identifier,
                     message=message,
                     text=json.dumps(message.to_dict()),
@@ -119,7 +119,7 @@ class _RetryQueue(Runnable):
             if next(data.expiration_generator)
         ]
 
-        def message_is_in_queue(data: _RetryQueue._MessageData) -> bool:
+        def message_is_in_queue(data: MessageQueue._MessageData) -> bool:
             return any(
                 isinstance(data.message, RetrieableMessage)
                 and send_event.message_identifier == data.message.message_identifier

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -107,9 +107,8 @@ class _RetryQueue(Runnable):
             self.log.warning("Can't retry", reason="Transport stopped")
             return
 
-        if self.transport_node._prioritize_global_messages:
-            # During startup global messages have to be sent first
-            self.transport_node._global_send_queue.join()
+        # During startup global messages have to be sent first
+        self.transport_node.enqueue_global_messages()
 
         self.log.debug("Retrying message", receiver=to_normalized_address(self.receiver))
 

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -157,7 +157,7 @@ class _RetryQueue(Runnable):
 
         if message_texts:
             self.log.debug("Send", receiver=pex(self.receiver), messages=message_texts)
-            self.transport_node.send_message(self.receiver, "\n".join(message_texts))
+            self.transport_node.send_message("\n".join(message_texts), self.receiver)
 
     @property
     def _queueids_to_queues(self) -> QueueIdsToQueues:

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -103,7 +103,7 @@ class _RetryQueue(Runnable):
         if not self.transport_node.greenlet:
             self.log.warning("Can't retry", reason="Transport not yet started")
             return
-        if self.transport_node._stop_event.ready():
+        if self.transport_node.stop_event.ready():
             self.log.warning("Can't retry", reason="Transport stopped")
             return
 
@@ -172,7 +172,7 @@ class _RetryQueue(Runnable):
             f"recipient:{pex(self.receiver)}"
         )
         # run while transport parent is running
-        while not self.transport_node._stop_event.ready():
+        while not self.transport_node.stop_event.ready():
             # once entered the critical section, block any other enqueue or notify attempt
             with self._lock:
                 self._notify_event.clear()

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -72,9 +72,9 @@ class _RetryQueue(Runnable):
                 )
                 return
             timeout_generator = udp_utils.timeout_exponential_backoff(
-                self.transport_node._config["retries_before_backoff"],
-                self.transport_node._config["retry_interval"],
-                self.transport_node._config["retry_interval"] * 10,
+                self.transport_node.config["retries_before_backoff"],
+                self.transport_node.config["retry_interval"],
+                self.transport_node.config["retry_interval"] * 10,
             )
             expiration_generator = self._expiration_generator(timeout_generator)
             self._message_queue.append(
@@ -158,11 +158,11 @@ class _RetryQueue(Runnable):
             self.transport_node._send_raw(self.receiver, "\n".join(message_texts))
 
     def _run(self):
-        msg = f"_RetryQueue started before transport._raiden_service is set"
-        assert self.transport_node._raiden_service is not None, msg
+        msg = f"_RetryQueue started before transport.raiden_service is set"
+        assert self.transport_node.raiden_service is not None, msg
         self.greenlet.name = (
             f"RetryQueue "
-            f"node:{pex(self.transport_node._raiden_service.address)} "
+            f"node:{pex(self.transport_node.raiden_service.address)} "
             f"recipient:{pex(self.receiver)}"
         )
         # run while transport parent is running
@@ -173,7 +173,7 @@ class _RetryQueue(Runnable):
                 if self._message_queue:
                     self._check_and_send()
             # wait up to retry_interval (or to be notified) before checking again
-            self._notify_event.wait(self.transport_node._config["retry_interval"])
+            self._notify_event.wait(self.transport_node.config["retry_interval"])
 
     def __str__(self):
         return self.greenlet.name

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -157,7 +157,7 @@ class _RetryQueue(Runnable):
 
         if message_texts:
             self.log.debug("Send", receiver=pex(self.receiver), messages=message_texts)
-            self.transport_node._send_raw(self.receiver, "\n".join(message_texts))
+            self.transport_node.send_message(self.receiver, "\n".join(message_texts))
 
     @property
     def _queueids_to_queues(self) -> QueueIdsToQueues:


### PR DESCRIPTION
This PR aims to solve issue [RLP-889](https://jirainfuy.atlassian.net/browse/RLP-889), which is about generalizing the `_RetryQueue` class so that it can be used with any type of transport node, instead of just `MatrixNode`.

## Design overview
The evident path to accomplish this task is to change matrix references from the `_RetryQueue` class to generic transport references (i.e. `MatrixTransportNode` → `TransportNode`). The problem with this approach is that the queue makes references to specific matrix node attributes rather than generic transport node ones. As a result, the abstract and concrete classes had to be modified (details below).

It's worth mentioning that the implementation is far from clean due to the coupling between these classes—both make references to each other; calls in one strict direction would be a more preferable design, but it's too big a task to tackle in the foreseeable future.

`_RetryQueue` **was renamed** to `MessageQueue`, since it better reflects the class purpose.

## Major changes
### Message-sending functions
Up until now, messages were first _enqueued_ through the transport node `send_message` function, but the actual sending of the message was only invoked in the `MessageQueue` class, through the (matrix) transport method `_send_raw`.

For better clarity, `TransportNode.send_message` was renamed to `enqueue_message`, and `_send_raw` was renamed to `send_message` and added to the transport node abstraction. Docstrings were also iterated to clear up how this is supposed to work: external entities should invoke the enqueuing, and only the message queue should invoke the actual sending from the transport node object. 

It would be better to have (the new) `send_message` as an internal method (and not part of the abstraction), but since this function is called by the—now transport-generic—message queue, it must be added to the generic transport node as well.

### `Runnable`
Up until now, `Runnable` was a superclass for `MatrixNode`. Since now `RifCommsNode` is also a subclass of `Runnable`, this inheritance was moved from the concrete nodes to the `TransportNode` abstract class. This is not only a cleaner design, but also helps with accessing transport node fields from the `MessageQueue` class.

As a result, `Runnable.__init__` is now called in the `TransportNode` constructor.

### `TransportNode`
New functions were added so that the `MessageQueue` class can use this abstraction as a type for its transport field:
1. `raiden_service` returns the `RaidenService` instance set in the node.
2. `config` returns the config dictionary set in the node.
3. `log` returns the node logger.
4. `enqueue_global_messages` is a function added only for the purposes of calling matrix-specific behavior in the `MessageQueue` class. As a result, it should be a no-op for `RifCommsNode`.

## Minor changes
- the `Runnable` class was refactored for tidiness purposes; a helper function was added and unnecessary code was removed.
- the `MessageQueue` class was moved out of the `transport.matrix` package, into the generic `transport.utils.py` file.
- the `MessageQueue.transport` field was renamed to `transport_node` for more clarity.
- `receiver` was substituted for `recipient` in some fields and logs for more clarity.
- `MatrixNode._stop_event` field was moved to the `Runnable` class, so that `MessageQueue.transport_node.stop_event` is congruent with the current abstractions (both transport nodes are `Runnables`, so this is a valid call). This field was also renamed so that it is "public".
- _Reformat Code_ and _Optimize Imports_ have been applied to all modified files.