### PR TITLE
RLP-850 Fixing insufficient funds error

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1237,11 +1237,6 @@ class RaidenAPI:
             token_address=token_address,
         )
 
-        # checking the balance before doing the payment to avoid problems on the state machine
-        chain_state = views.state_from_raiden(self.raiden)
-
-
-
         self.raiden.mediated_transfer_async_light(
             token_network_identifier=token_network_identifier,
             amount=amount,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2371,6 +2371,8 @@ class RestAPI:
             return api_response(hub_message.to_dict())
         except ChannelNotFound as e:
             return ApiErrorBuilder.build_and_log_error(errors=str(e), status_code=HTTPStatus.NOT_FOUND, log=log)
+        except InsufficientFunds as e:
+            return ApiErrorBuilder.build_and_log_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED, log=log)
         except UnhandledLightClient as e:
             return ApiErrorBuilder.build_and_log_error(errors=str(e), status_code=HTTPStatus.FORBIDDEN, log=log)
 


### PR DESCRIPTION
### Problem
When we send a payment from an LC and we don't wait and send again another payment on the same channel that has an amount greater than the total available balance on the channel the hub fails and stop working.

### Cause
This was because we have an assert on the state machine that checks the balances before starting a payment.

### Solution
We have added some checks before creating and initiating the payment to avoid that error

### Changes

* Adding control before creating payment
* Adding control before initiating payment

* This affects the payments light