### PR TITLE
RLP-885 test_mediatedtransfer_invalid.py

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -27,20 +27,19 @@ from raiden.utils.signer import LocalSigner
 
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_failsfast_lockedtransfer_exceeding_distributable(
-    raiden_network, token_addresses, deposit
-):
+def test_failsfast_lockedtransfer_exceeding_distributable(raiden_network, token_addresses, deposit, network_wait):
     raise_on_failure(
         raiden_network,
         run_test_failsfast_lockedtransfer_exceeding_distributable,
         raiden_network=raiden_network,
         token_addresses=token_addresses,
         deposit=deposit,
+        network_wait=network_wait
     )
 
 
 def run_test_failsfast_lockedtransfer_exceeding_distributable(
-    raiden_network, token_addresses, deposit
+    raiden_network, token_addresses, deposit, network_wait
 ):
 
     app0, app1 = raiden_network
@@ -58,7 +57,17 @@ def run_test_failsfast_lockedtransfer_exceeding_distributable(
     assert payment_status.payment_done.get(timeout=5) is False
     assert payment_status.payment_done.successful()
 
-    assert_synced_channel_state(token_network_identifier, app0, deposit, [], app1, deposit, [])
+    with gevent.Timeout(network_wait):
+        wait_assert(
+            assert_synced_channel_state,
+            token_network_identifier,
+            app0,
+            deposit,
+            [],
+            app1,
+            deposit,
+            [],
+        )
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -168,7 +177,7 @@ def run_test_receive_lockedtransfer_invalidnonce(
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_receive_lockedtransfer_invalidsender(
-    raiden_network, token_addresses, deposit, reveal_timeout
+    raiden_network, token_addresses, deposit, reveal_timeout, network_wait
 ):
     raise_on_failure(
         raiden_network,
@@ -177,11 +186,12 @@ def test_receive_lockedtransfer_invalidsender(
         token_addresses=token_addresses,
         deposit=deposit,
         reveal_timeout=reveal_timeout,
+        network_wait=network_wait
     )
 
 
 def run_test_receive_lockedtransfer_invalidsender(
-    raiden_network, token_addresses, deposit, reveal_timeout
+    raiden_network, token_addresses, deposit, reveal_timeout, network_wait
 ):
 
     app0, app1 = raiden_network
@@ -215,13 +225,23 @@ def run_test_receive_lockedtransfer_invalidsender(
 
     sign_and_inject(mediated_transfer_message, LocalSigner(other_key), app0)
 
-    assert_synced_channel_state(token_network_identifier, app0, deposit, [], app1, deposit, [])
+    with gevent.Timeout(network_wait):
+        wait_assert(
+            assert_synced_channel_state,
+            token_network_identifier,
+            app0,
+            deposit,
+            [],
+            app1,
+            deposit,
+            [],
+        )
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_receive_lockedtransfer_invalidrecipient(
-    raiden_network, token_addresses, reveal_timeout, deposit
+    raiden_network, token_addresses, reveal_timeout, deposit, network_wait
 ):
     raise_on_failure(
         raiden_network,
@@ -230,11 +250,12 @@ def test_receive_lockedtransfer_invalidrecipient(
         token_addresses=token_addresses,
         reveal_timeout=reveal_timeout,
         deposit=deposit,
+        network_wait=network_wait
     )
 
 
 def run_test_receive_lockedtransfer_invalidrecipient(
-    raiden_network, token_addresses, reveal_timeout, deposit
+    raiden_network, token_addresses, reveal_timeout, deposit, network_wait
 ):
 
     app0, app1 = raiden_network
@@ -269,14 +290,24 @@ def run_test_receive_lockedtransfer_invalidrecipient(
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
 
-    assert_synced_channel_state(token_network_identifier, app0, deposit, [], app1, deposit, [])
+    with gevent.Timeout(network_wait):
+        wait_assert(
+            assert_synced_channel_state,
+            token_network_identifier,
+            app0,
+            deposit,
+            [],
+            app1,
+            deposit,
+            [],
+        )
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("settle_timeout", [30])
 def test_received_lockedtransfer_closedchannel(
-    raiden_network, reveal_timeout, token_addresses, deposit
+    raiden_network, reveal_timeout, token_addresses, deposit, network_wait
 ):
     raise_on_failure(
         raiden_network,
@@ -285,11 +316,12 @@ def test_received_lockedtransfer_closedchannel(
         reveal_timeout=reveal_timeout,
         token_addresses=token_addresses,
         deposit=deposit,
+        network_wait=network_wait
     )
 
 
 def run_test_received_lockedtransfer_closedchannel(
-    raiden_network, reveal_timeout, token_addresses, deposit
+    raiden_network, reveal_timeout, token_addresses, deposit, network_wait
 ):
 
     app0, app1 = raiden_network
@@ -329,5 +361,14 @@ def run_test_received_lockedtransfer_closedchannel(
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
 
-    # The local state must not change since the channel is already closed
-    assert_synced_channel_state(token_network_identifier, app0, deposit, [], app1, deposit, [])
+    with gevent.Timeout(network_wait):
+        wait_assert(
+            assert_synced_channel_state,
+            token_network_identifier,
+            app0,
+            deposit,
+            [],
+            app1,
+            deposit,
+            [],
+        )


### PR DESCRIPTION
## Problem
The test seems to be flaky in this branch because some times it fails on an assert check.

## Cause
The assert fails because it's checking the channel balance after triggering some operations. The problem is that sometimes those operations take too long and the assert it's being checking the condition before the data can be valid.

## Solution
The problem was the way to call this function `assert_synced_channel_state` where it was directly called instead of using the helper function for tests called `wait_assert`. That other function waits for the value to be ready to assert and then it checks the value. Also it has a gevent timeout to make sure that if something is not ok it will fail anyway.

## Why it works on develop?
Probably because with all the changes that we are introducing on this branch the test here is taking more time to complete compared to develop branch.
