### PR TITLE
RLP-892: RIF Comms improvements & bugfixes

### DIFF
--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,6 +1,6 @@
-const backendUrl='http://localhost:5002';
-const nodeAddress = '0x62Aa1173561C4E92876B3D073B9767A2d07496f8';
-const rnsDomain = null;
+const backendUrl='http://localhost:5019'; 
+const nodeAddress = '0x138aF366e0ED7Cc4b9747a935D1b5F75A86b9D83'; 
+const rnsDomain = null 
 const chainEndpoint = 'http://localhost:4444'; 
 
 window.luminoUrl = backendUrl;

--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,6 +1,6 @@
-const backendUrl='http://localhost:5019'; 
-const nodeAddress = '0x138aF366e0ED7Cc4b9747a935D1b5F75A86b9D83'; 
-const rnsDomain = null 
+const backendUrl='http://localhost:5002';
+const nodeAddress = '0x62Aa1173561C4E92876B3D073B9767A2d07496f8';
+const rnsDomain = null;
 const chainEndpoint = 'http://localhost:4444'; 
 
 window.luminoUrl = backendUrl;

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -71,7 +71,10 @@ class App:  # pylint: disable=too-few-public-methods
                 "server": "auto",
             },
             "rif_comms": {
-                "grpc_endpoint": DEFAULT_RIF_COMMS_GRPC_ENDPOINT
+                "grpc_endpoint": DEFAULT_RIF_COMMS_GRPC_ENDPOINT,
+                "retries_before_backoff": DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
+                "retry_interval": DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL
+
             }
         },
         "rpc": True,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -9,7 +9,6 @@ from eth_utils import (
     to_normalized_address,
     to_checksum_address
 )
-
 from raiden.constants import UINT64_MAX, UINT256_MAX, EMPTY_PAYMENT_HASH_INVOICE
 from raiden.encoding import messages
 from raiden.encoding.format import buffer_for
@@ -21,7 +20,6 @@ from raiden.transfer.balance_proof import (
     pack_reward_proof,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
-
 from raiden.transfer.state import BalanceProofSignedState
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import ishash, pex, sha3
@@ -73,6 +71,7 @@ __all__ = (
     "SecretRequest",
     "SignedBlindedBalanceProof",
     "SignedMessage",
+    "SignedRetrieableMessage",
     "ToDevice",
     "Unlock",
     "decode",
@@ -154,7 +153,6 @@ def from_dict(data: dict) -> "Message":
                 "Invalid message data. Can not find the data type"
             ) from None
     return klass.from_dict(data)
-
 
 
 class Message:
@@ -1366,7 +1364,7 @@ class RefundTransfer(LockedTransfer):
             "chain_id": self.chain_id,
             "message_identifier": self.message_identifier,
             "payment_identifier": self.payment_identifier,
-            "payment_hash_invoice" : encode_hex(self.payment_hash_invoice),
+            "payment_hash_invoice": encode_hex(self.payment_hash_invoice),
             "nonce": self.nonce,
             "token_network_address": to_normalized_address(self.token_network_address),
             "token": to_normalized_address(self.token),
@@ -1428,7 +1426,6 @@ class LockExpired(EnvelopeMessage):
         secrethash: SecretHash,
         **kwargs,
     ):
-
         super().__init__(
             chain_id=chain_id,
             nonce=nonce,
@@ -1902,12 +1899,12 @@ class RequestRegisterSecret(Message):
         self.secret_registry_address = secret_registry_address
 
     def __eq__(self, other):
-
         return (
             super().__eq__(other)
             and isinstance(other, RequestRegisterSecret)
             and self.secret_registry_address == other.secret_registry_address
         )
+
     @classmethod
     def unpack(cls, packed):
         return cls(packed.secret_registry_address)
@@ -1928,6 +1925,7 @@ class RequestRegisterSecret(Message):
 
 class SettlementRequiredLightMessage(Message):
     """ Represents the settlement required message for the LC when we need the LC to sign and send a settlement """
+
     def __init__(self, channel_identifier: ChannelID, channel_network_identifier: TokenNetworkAddress,
                  participant1: Address, participant1_transferred_amount: TokenAmount,
                  participant1_locked_amount: TokenAmount, participant1_locksroot: Locksroot, participant2: Address,

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -8,8 +8,7 @@ from coincurve import PublicKey
 from eth_utils import to_checksum_address
 from grpc._channel import _InactiveRpcError
 from sha3 import keccak_256
-
-from transport.rif_comms.client import RifCommsClient
+from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.proto.api_pb2 import RskAddress, Channel, Subscriber, PublishPayload, Msg
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
@@ -33,7 +32,7 @@ UNREGISTERED_ADDRESS = get_random_address_str()
 @pytest.mark.usefixtures("rif_comms_client")
 @pytest.fixture(scope="class")
 def rif_comms_client(request):
-    rif_comms_client = RifCommsClient(LUMINO_1_ADDRESS, LUMINO_1_COMMS_API)
+    rif_comms_client = RIFCommsClient(LUMINO_1_ADDRESS, LUMINO_1_COMMS_API)
 
     def teardown():
         rif_comms_client.disconnect()

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -67,10 +67,12 @@ class TestRiffCommsClient(unittest.TestCase):
 
     @pytest.mark.skip(reason="ignore")
     def test_locate_unregistered_peer_id(self):
+        # TODO: this should be fixed with the next RIF Comms pub-sub release
         self.assertRaises(_InactiveRpcError, lambda: self.rif_comms_client._get_peer_id(UNREGISTERED_ADDRESS))
 
     @pytest.mark.skip(reason="ignore")
     def test_create_random_topic_id_without_connection(self):
+        # TODO: this should be fixed with the next RIF Comms pub-sub release
         notification = self.rif_comms_client.connect()
         peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         channel = self.rif_comms_client.subscribe_to(get_random_address_str())
@@ -78,6 +80,7 @@ class TestRiffCommsClient(unittest.TestCase):
 
     @pytest.mark.skip(reason="ignore")
     def test_subscribe(self):
+        # TODO: this is failing with "peer is not subscribed to"
         channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
         stub = CommunicationsApiStub(channel)
         rsk_address = RskAddress(address=LUMINO_1_ADDRESS)
@@ -87,6 +90,7 @@ class TestRiffCommsClient(unittest.TestCase):
 
     @pytest.mark.skip(reason="ignore")
     def test_has_subscriber(self):
+        # TODO: test with RSK address instead of peer ID
         channel = grpc.insecure_channel(LUMINO_1_COMMS_API)
         stub = CommunicationsApiStub(channel)
         rsk_address = RskAddress(address=LUMINO_1_ADDRESS)
@@ -119,7 +123,9 @@ class TestRiffCommsClient(unittest.TestCase):
         channel = grpc.insecure_channel(LUMINO_2_COMMS_API)
         stub = CommunicationsApiStub(channel)
         channel = stub.Subscribe(Channel(
-            channelId="16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA"))  # got this from subscription of lumino node
+            channelId="16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA")
+            # got this from subscription of lumino node
+        )
 
         some_raiden_message = {
             'type': 'LockedTransfer',

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -62,20 +62,20 @@ class TestRiffCommsClient(unittest.TestCase):
     @pytest.mark.skip(reason="ignore")
     def test_locate_peer_id(self):
         response = self.rif_comms_client.connect()
-        peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
+        peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         print(f"test_locate_peer_id peer_id = {peer_id}")
         assert peer_id is not None
 
     @pytest.mark.skip(reason="ignore")
     def test_locate_unregistered_peer_id(self):
-        self.assertRaises(_InactiveRpcError, lambda: self.rif_comms_client.get_peer_id(UNREGISTERED_ADDRESS))
+        self.assertRaises(_InactiveRpcError, lambda: self.rif_comms_client._get_peer_id(UNREGISTERED_ADDRESS))
 
     @pytest.mark.skip(reason="ignore")
     def test_create_random_topic_id_without_connection(self):
         notification = self.rif_comms_client.connect()
-        peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
+        peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         channel = self.rif_comms_client.subscribe(get_random_address_str())
-        peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
+        peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
 
     @pytest.mark.skip(reason="ignore")
     def test_subscribe(self):
@@ -112,7 +112,7 @@ class TestRiffCommsClient(unittest.TestCase):
     @pytest.mark.skip(reason="ignore")
     def test_disconnect(self):
         notification = self.rif_comms_client.connect()
-        peer_id = self.rif_comms_client.get_peer_id(LUMINO_1_ADDRESS)
+        peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         self.rif_comms_client.disconnect()
 
     @pytest.mark.skip(reason="ignore")

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -74,7 +74,7 @@ class TestRiffCommsClient(unittest.TestCase):
     def test_create_random_topic_id_without_connection(self):
         notification = self.rif_comms_client.connect()
         peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
-        channel = self.rif_comms_client.subscribe(get_random_address_str())
+        channel = self.rif_comms_client.subscribe_to(get_random_address_str())
         peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
 
     @pytest.mark.skip(reason="ignore")

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -118,6 +118,7 @@ class TestRiffCommsClient(unittest.TestCase):
         peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         self.rif_comms_client.disconnect()
 
+    @pytest.mark.skip(reason="ignore")
     def test_send_lumino_message(self):
         channel = grpc.insecure_channel(LUMINO_2_COMMS_API)
         stub = CommunicationsApiStub(channel)

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -5,7 +5,7 @@ import unittest
 import grpc
 import pytest
 from coincurve import PublicKey
-from eth_utils import to_checksum_address
+from eth_utils import to_checksum_address, to_canonical_address
 from grpc._channel import _InactiveRpcError
 from sha3 import keccak_256
 from transport.rif_comms.client import Client as RIFCommsClient
@@ -20,11 +20,11 @@ def get_random_address_str() -> str:
     return to_checksum_address(addr)
 
 
-LUMINO_1_ADDRESS = "0xe717e81105471648a152381aE6De4c878343E2sb2"
+LUMINO_1_ADDRESS = to_canonical_address("0x8cb891510dF75C223C53f910A98c3b61B9083c3B")
 LUMINO_1_COMMS_API = "localhost:5013"
 
 LUMINO_2_COMMS_API = "localhost:5016"
-LUMINO_2_ADDRESS = "0x138af366e0ed7cc4b9747a935d1b5f75a86b9d83"
+LUMINO_2_ADDRESS = to_canonical_address("0xeBfF0EEe8E2b6952E589B0475e3F0E34dA0655B1")
 
 UNREGISTERED_ADDRESS = get_random_address_str()
 
@@ -118,7 +118,6 @@ class TestRiffCommsClient(unittest.TestCase):
         peer_id = self.rif_comms_client._get_peer_id(LUMINO_1_ADDRESS)
         self.rif_comms_client.disconnect()
 
-    @pytest.mark.skip(reason="ignore")
     def test_send_lumino_message(self):
         channel = grpc.insecure_channel(LUMINO_2_COMMS_API)
         stub = CommunicationsApiStub(channel)

--- a/transport/factory.py
+++ b/transport/factory.py
@@ -1,6 +1,6 @@
 from transport.layer import Layer as TransportLayer
 from transport.matrix.layer import MatrixLayer as MatrixTransportLayer
-from transport.rif_comms.layer import RifCommsLayer as RifCommsTransportLayer
+from transport.rif_comms.layer import Layer as RIFCommsTransportLayer
 
 
 class Factory:
@@ -11,6 +11,6 @@ class Factory:
     @staticmethod
     def create(transport_type: str, config: dict) -> TransportLayer:
         if transport_type == "rif-comms":
-            return RifCommsTransportLayer(config)
+            return RIFCommsTransportLayer(config)
         elif transport_type == "matrix":
             return MatrixTransportLayer(config)

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -310,7 +310,7 @@ class MatrixNode(TransportNode):
             )
 
         self.log.info(
-            "Send message",
+            "Enqueue message",
             recipient=pex(recipient),
             message=raiden_message,
             queue_identifier=queue_identifier,

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -11,7 +11,6 @@ from gevent.event import Event
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixRequestError
 from matrix_client.user import User
-
 from raiden.constants import DISCOVERY_DEFAULT_ROOM
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress
 from raiden.message_handler import MessageHandler
@@ -179,7 +178,7 @@ class MatrixNode(TransportNode):
 
         # (re)start any _RetryQueue which was initialized before start
         for retrier in self._address_to_retrier.values():
-            if not retrier:
+            if not retrier.greenlet:
                 self.log.debug("Starting retrier", retrier=retrier)
                 retrier.start()
 

--- a/transport/matrix/node.py
+++ b/transport/matrix/node.py
@@ -194,7 +194,7 @@ class MatrixNode(TransportNode):
         self.greenlet.name = f"MatrixTransport._run node:{pex(self._raiden_service.address)}"
         self._raiden_service.handle_and_track_state_change(state_change)
         try:
-            # waits on _stop_event.ready()
+            # waits on stop_event.ready()
             self._global_send_worker()
             # children crashes should throw an exception here
         except gevent.GreenletExit:  # killed without exception
@@ -1216,7 +1216,7 @@ class MatrixLightClientNode(MatrixNode):
         self.greenlet.name = f"MatrixLightClientTransport._run light_client:{to_canonical_address(self.address)}"
         self._raiden_service.handle_and_track_state_change(state_change)
         try:
-            # waits on _stop_event.ready()
+            # waits on stop_event.ready()
             self._global_send_worker()
             # children crashes should throw an exception here
         except gevent.GreenletExit:  # killed without exception

--- a/transport/node.py
+++ b/transport/node.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from raiden.messages import Message
 from raiden.utils import Address
 from raiden.utils.runnable import Runnable
+from transport.message import Message
 
 
 class Node(ABC, Runnable):

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -37,7 +37,7 @@ class RifCommsClient:
         """
         return self.stub.ConnectToCommunicationsNode(self.rsk_address)
 
-    def subscribe(self, rsk_address: Address) -> Notification:
+    def subscribe_to(self, rsk_address: Address) -> Notification:
         """
         Subscribes to a pub-sub topic in order to send messages to or receive messages from an address.
         Invokes CreateTopicWithRskAddress GRPC API endpoint.

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -65,11 +65,11 @@ class Client:
             )
         ).value
 
-    def send_message(self, message_payload: str, rsk_address: Address):
+    def send_message(self, payload: str, rsk_address: Address):
         """
         Sends a message to a destination RSK address.
         Invokes the SendMessageToTopic GRPC API endpoint.
-        :param message_payload: the message data to be sent
+        :param payload: the message data to be sent
         :param rsk_address: the destination for the message to be sent to
         """
         topic_id = self._get_peer_id(rsk_address)
@@ -77,7 +77,7 @@ class Client:
         self.stub.SendMessageToTopic(
             PublishPayload(
                 topic=Channel(channelId=topic_id),
-                message=Msg(payload=str.encode(message_payload))
+                message=Msg(payload=str.encode(payload))
             )
         )
 

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -57,7 +57,7 @@ class Client:
         :param rsk_address: RSK address which corresponds to the topic which is being checked for subscription
         :return: boolean value indicating whether the client is subscribed or not
         """
-        our_peer_id = self._get_peer_id(self.rsk_address)
+        our_peer_id = self._get_peer_id(self.rsk_address.address)
         topic_id = self._get_peer_id(to_checksum_address(rsk_address))
         return self.stub.HasSubscriber(
             Subscriber(

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -13,7 +13,7 @@ from transport.rif_comms.proto.api_pb2 import (
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
 
-class RifCommsClient:
+class Client:
     """
     Class to connect and operate against a RIF Communications pub-sub node.
     """

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -81,7 +81,7 @@ class Client:
             )
         )
 
-    def unsubscribe(self, rsk_address: str):
+    def unsubscribe_from(self, rsk_address: Address):
         """
         Unsubscribes from a topic which corresponds to the given RSK address.
         Invokes the CloseTopic GRPC API endpoint.

--- a/transport/rif_comms/layer.py
+++ b/transport/rif_comms/layer.py
@@ -1,13 +1,13 @@
 from raiden.utils import Address
-from transport.node import Node as TransportNode
-from transport.rif_comms.node import RifCommsNode
 from transport.layer import Layer as TransportLayer
+from transport.node import Node as TransportNode
+from transport.rif_comms.node import Node as RIFCommsTransportNode
 
 
-class RifCommsLayer(TransportLayer[RifCommsNode]):
+class Layer(TransportLayer[RIFCommsTransportNode]):
 
     def construct_full_node(self, config):
-        return RifCommsNode(config["address"], config["transport"]["rif_comms"])
+        return RIFCommsTransportNode(config["address"], config["transport"]["rif_comms"])
 
     def construct_light_clients_nodes(self, config):
         return []
@@ -17,4 +17,3 @@ class RifCommsLayer(TransportLayer[RifCommsNode]):
 
     def register_light_client(self, raiden_api: 'RaidenAPI', registration_data: dict) -> TransportNode:
         pass
-

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -283,13 +283,12 @@ class Node(TransportNode):
         Send text message through the RIF Comms client.
         """
         # check if we have a subscription for that receiver address
-        to_checksum_recipient = to_checksum_address(recipient)
-        is_subscribed_to_receiver_topic = self._comms_client.is_subscribed_to(to_checksum_recipient)
+        is_subscribed_to_receiver_topic = self._comms_client.is_subscribed_to(recipient)
         # if not, create the topic subscription
         if not is_subscribed_to_receiver_topic:
-            self._comms_client.subscribe_to(to_checksum_recipient)
+            self._comms_client.subscribe_to(recipient)
         # send the message
-        self._comms_client.send_message(payload, to_checksum_recipient)  # TODO: exception handling for RIF Comms client
+        self._comms_client.send_message(payload, recipient)  # TODO: exception handling for RIF Comms client
         self.log.info(
             "RIF Comms send message", message_payload=payload.replace("\n", "\\n"), recipient=pex(recipient)
         )

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -46,7 +46,7 @@ class Node(TransportNode):
         self._our_topic_stream: Notification = None
         self._our_topic_thread: Greenlet = None
         self._comms_client = RIFCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
-        print("RifCommsNode init on GRPC endpoint: {}".format(self._config["grpc_endpoint"]))
+        print("RIFCommsNode init on GRPC endpoint: {}".format(self._config["grpc_endpoint"]))
 
         # initialize message queues
         self._address_to_message_queue: Dict[Address, MessageQueue] = dict()

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -174,7 +174,7 @@ class RifCommsNode(TransportNode):
         else:
             self.log.warning("unexpected type of message received", message=message)
 
-    def _ack_message(self, message: RaidenMessage):
+    def _ack_message(self, message: (Delivered, Processed, SignedRetrieableMessage)):
         """
         Acknowledge a received Raiden message by sending a Delivered-type message back.
         If the received Raiden message is of the Delivered type, no action is taken.

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -3,8 +3,9 @@ from typing import Any, Dict
 
 import structlog
 from eth_utils import is_binary_address
-from gevent import killall, wait
+from gevent import wait
 from greenlet import GreenletExit
+
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress
 from raiden.message_handler import MessageHandler
 from raiden.messages import (
@@ -66,8 +67,6 @@ class Node(TransportNode):
         # connect to rif comms node
         # TODO: this shouldn't need to be assigned, it is only done because otherwise the code hangs
         self._rif_comms_connect_stream = self._comms_client.connect()
-
-        # subscribe to our own topic to receive messages
         self._start_message_listener()
 
         # start pre-loaded message queues
@@ -87,6 +86,7 @@ class Node(TransportNode):
         """
         our_address = self.raiden_service.address
         self._our_topic_stream = self._comms_client.subscribe_to(our_address)
+
 
     def _receive_messages(self):
         """
@@ -186,9 +186,9 @@ class Node(TransportNode):
             self.log.info("RIF Comms Node _run")
         except GreenletExit:  # killed without exception
             self.stop_event.set()
-            killall(self._our_topic_thread)  # kill children
             raise  # re-raise to keep killed status
-        except Exception:
+        except Exception as e:
+            print(e)
             self.stop()  # ensure cleanup and wait on subtasks
             raise
 

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -18,10 +18,8 @@ from raiden.messages import (
     from_dict as message_from_dict
 )
 from raiden.raiden_service import RaidenService
-from raiden.transfer import views
 from raiden.transfer.identifiers import QueueIdentifier
 from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_QUEUE
-from raiden.transfer.state import QueueIdsToQueues
 from raiden.utils import pex
 from raiden.utils.runnable import Runnable
 from raiden.utils.typing import Address
@@ -56,11 +54,6 @@ class RifCommsNode(TransportNode):
         self._stop_event.set()
 
         self._log = log.bind(node_address=pex(self.address))
-
-    @property
-    def _queueids_to_queues(self) -> QueueIdsToQueues:
-        chain_state = views.state_from_raiden(self._raiden_service)
-        return views.get_all_messagequeues(chain_state)
 
     def start(self, raiden_service: RaidenService, message_handler: MessageHandler, prev_auth_data: str):
         self._raiden_service = raiden_service

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Dict
 
 import structlog
-from eth_utils import to_checksum_address, is_binary_address
+from eth_utils import is_binary_address
 from gevent import Greenlet, killall, wait, spawn
 from greenlet import GreenletExit
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress
@@ -45,7 +45,7 @@ class Node(TransportNode):
         self._rif_comms_connect_stream: Notification = None
         self._our_topic_stream: Notification = None
         self._our_topic_thread: Greenlet = None
-        self._comms_client = RIFCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
+        self._comms_client = RIFCommsClient(address, self._config["grpc_endpoint"])
         print("RIFCommsNode init on GRPC endpoint: {}".format(self._config["grpc_endpoint"]))
 
         # initialize message queues
@@ -86,7 +86,7 @@ class Node(TransportNode):
         """
         Start a listener greenlet to listen for received messages in the background.
         """
-        our_address = to_checksum_address(self.raiden_service.address)
+        our_address = self.raiden_service.address
         self._our_topic_stream = self._comms_client.subscribe_to(our_address)
         # TODO: remove this after GRPC API request blocking is fixed
         self._comms_client._get_peer_id(our_address)

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -177,7 +177,7 @@ class Node(TransportNode):
             self.log.info("RIF Comms Node _run. Listening for messages.")
         except GreenletExit:  # killed without exception
             self.stop_event.set()
-            killall(self._our_topic_thread)  # kill children
+            killall(self.greenlet)  # kill children
             raise  # re-raise to keep killed status
         except Exception:
             self.stop()  # ensure cleanup and wait on subtasks

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -85,7 +85,9 @@ class RifCommsNode(TransportNode):
         return f"<{self.__class__.__name__}{node} id:{id(self)}>"
 
     def _run(self, *args: Any, **kwargs: Any) -> None:
-        """ Runnable main method, perform wait on long-running subtasks """
+        """
+        Runnable main method, perform wait on long-running subtasks
+        """
         # dispatch auth data on first scheduling after start
         self.greenlet.name = f"RifCommsNode._run node:{pex(self._raiden_service.address)}"
         try:
@@ -136,18 +138,18 @@ class RifCommsNode(TransportNode):
         # we don't call it here to avoid deadlock when self crashes and calls stop() on finally
 
     def enqueue_message(self, message: TransportMessage, recipient: Address):
-        """Queue the message for sending to recipient
+        """
+        Queue the message for sending to recipient.
 
-        It may be called before transport is started, to initialize message queues
-        The actual sending is started only when the transport is started
+        It may be called before transport is started, to initialize message queues.
+        The actual sending is started only when the transport is started.
         """
         raiden_message, queue_identifier = TransportMessage.unwrap(message)
 
-        # even if transport is not started, can run to enqueue messages to send when it starts
         if not is_binary_address(recipient):
             raise ValueError("Invalid address {}".format(pex(recipient)))
 
-        # These are not protocol messages, but transport specific messages
+        # these are not protocol messages, but transport specific messages
         if isinstance(raiden_message, (Ping, Pong)):
             raise ValueError(
                 "Do not use send_message for {} messages".format(raiden_message.__class__.__name__)
@@ -160,8 +162,8 @@ class RifCommsNode(TransportNode):
             queue_identifier=queue_identifier,
         )
 
-        queue = self._get_queue(queue_identifier.recipient)
-        queue.enqueue(queue_identifier=queue_identifier, message=raiden_message)
+        message_queue = self._get_queue(queue_identifier.recipient)
+        message_queue.enqueue(queue_identifier=queue_identifier, message=raiden_message)
 
     def _get_queue(self, recipient: Address) -> MessageQueue:
         """ Construct and return a MessageQueue for recipient """
@@ -181,7 +183,7 @@ class RifCommsNode(TransportNode):
         is_subscribed_to_receiver_topic = self._comms_client.has_subscription(recipient).value
         if not is_subscribed_to_receiver_topic:
             # If not, create the topic subscription
-            self._comms_client.subscribe(recipient)  # TODO is this really needed in order to send msg to receiver?
+            self._comms_client.subscribe(recipient)  # TODO: is this really needed in order to send msg to receiver?
         # Send the message
         self._comms_client.send_message(recipient, payload)
         self.log.info(

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -84,17 +84,18 @@ class RifCommsNode(TransportNode):
 
         return f"<{self.__class__.__name__}{node} id:{id(self)}>"
 
-    def _run(self) -> None:
+    def _run(self, *args: Any, **kwargs: Any) -> None:
         """ Runnable main method, perform wait on long-running subtasks """
         # dispatch auth data on first scheduling after start
         self.greenlet.name = f"RifCommsNode._run node:{pex(self._raiden_service.address)}"
         try:
             # waits on _stop_event.ready()
             # children crashes should throw an exception here
+            # TODO: figure out if something else is needed here
             self.log.info("RIF Comms _run")
         except GreenletExit:  # killed without exception
             self._stop_event.set()
-            killall(self.greenlets)  # kill children
+            killall(self._our_topic_thread)  # kill children
             raise  # re-raise to keep killed status
         except Exception:
             self.stop()  # ensure cleanup and wait on subtasks

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -87,7 +87,7 @@ class RifCommsNode(TransportNode):
         Start a listener greenlet to listen for received messages in the background.
         """
         our_address = to_checksum_address(self.raiden_service.address)
-        self._our_topic_stream = self._comms_client.subscribe(our_address)
+        self._our_topic_stream = self._comms_client.subscribe_to(our_address)
         # TODO: remove this after GRPC API request blocking is fixed
         self._comms_client._get_peer_id(our_address)
         self._our_topic_thread = spawn(self._receive_messages)
@@ -291,7 +291,7 @@ class RifCommsNode(TransportNode):
         is_subscribed_to_receiver_topic = self._comms_client.is_subscribed_to(recipient)
         # if not, create the topic subscription
         if not is_subscribed_to_receiver_topic:
-            self._comms_client.subscribe(recipient)
+            self._comms_client.subscribe_to(recipient)
         # send the message
         self._comms_client.send_message(payload, recipient)  # TODO: exception handling for RIF Comms client
         self.log.info(

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -24,14 +24,14 @@ from raiden.utils.runnable import Runnable
 from raiden.utils.typing import Address
 from transport.message import Message as TransportMessage
 from transport.node import Node as TransportNode
-from transport.rif_comms.client import RifCommsClient
+from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.proto.api_pb2 import Notification, ChannelNewData
 from transport.utils import MessageQueue
 
 log = structlog.get_logger(__name__)
 
 
-class RifCommsNode(TransportNode):
+class Node(TransportNode):
     _log = log
 
     def __init__(self, address: Address, config: dict):
@@ -45,7 +45,7 @@ class RifCommsNode(TransportNode):
         self._rif_comms_connect_stream: Notification = None
         self._our_topic_stream: Notification = None
         self._our_topic_thread: Greenlet = None
-        self._comms_client = RifCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
+        self._comms_client = RIFCommsClient(to_checksum_address(address), self._config["grpc_endpoint"])
         print("RifCommsNode init on GRPC endpoint: {}".format(self._config["grpc_endpoint"]))
 
         # initialize message queues
@@ -91,7 +91,7 @@ class RifCommsNode(TransportNode):
         # TODO: remove this after GRPC API request blocking is fixed
         self._comms_client._get_peer_id(our_address)
         self._our_topic_thread = spawn(self._receive_messages)
-        self._our_topic_thread.name = f"RifCommsClient.listen_messages rsk_address:{self.address}"
+        self._our_topic_thread.name = f"RIFCommsClient.listen_messages rsk_address:{self.address}"
 
     def _receive_messages(self):
         """
@@ -183,7 +183,7 @@ class RifCommsNode(TransportNode):
         Runnable main method, perform wait on long-running subtasks.
         """
         # dispatch auth data on first scheduling after start
-        self.greenlet.name = f"RifCommsNode._run node:{pex(self._raiden_service.address)}"
+        self.greenlet.name = f"RIFCommsNode._run node:{pex(self._raiden_service.address)}"
         try:
             # waits on stop_event.ready()
             # children crashes should throw an exception here
@@ -327,7 +327,7 @@ class RifCommsNode(TransportNode):
         return f"<{self.__class__.__name__}{node} id:{id(self)}>"
 
 
-class RifCommsLightClientNode(RifCommsNode):
+class LightClientNode(Node):
 
     def __init__(self, address: Address, config: dict, auth_params: dict):
-        RifCommsNode.__init__(self, address, config)
+        Node.__init__(self, address, config)

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -173,11 +173,8 @@ class RifCommsNode(TransportNode):
             queue_identifier=queue_identifier,
         )
 
-        self._enqueue_message(queue_identifier, raiden_message)
-
-    def _enqueue_message(self, queue_identifier: QueueIdentifier, message: Message):
         queue = self._get_queue(queue_identifier.recipient)
-        queue.enqueue(queue_identifier=queue_identifier, message=message)
+        queue.enqueue(queue_identifier=queue_identifier, message=raiden_message)
 
     def _get_queue(self, recipient: Address) -> MessageQueue:
         """ Construct and return a MessageQueue for recipient """

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -89,7 +89,7 @@ class RifCommsNode(TransportNode):
         our_address = to_checksum_address(self.raiden_service.address)
         self._our_topic_stream = self._comms_client.subscribe(our_address)
         # TODO: remove this after GRPC API request blocking is fixed
-        self._comms_client.get_peer_id(our_address)
+        self._comms_client._get_peer_id(our_address)
         self._our_topic_thread = spawn(self._receive_messages)
         self._our_topic_thread.name = f"RifCommsClient.listen_messages rsk_address:{self.address}"
 
@@ -288,14 +288,14 @@ class RifCommsNode(TransportNode):
         Send text message through the RIF Comms client.
         """
         # check if we have a subscription for that receiver address
-        is_subscribed_to_receiver_topic = self._comms_client.has_subscription(recipient).value
+        is_subscribed_to_receiver_topic = self._comms_client.is_subscribed_to(recipient)
         # if not, create the topic subscription
         if not is_subscribed_to_receiver_topic:
             self._comms_client.subscribe(recipient)
         # send the message
-        self._comms_client.send_message(recipient, payload)  # TODO: exception handling for RIF Comms client
+        self._comms_client.send_message(payload, recipient)  # TODO: exception handling for RIF Comms client
         self.log.info(
-            "RIF Comms send message", recipient=pex(recipient), data=payload.replace("\n", "\\n")
+            "RIF Comms send message", message_payload=payload.replace("\n", "\\n"), recipient=pex(recipient)
         )
 
     def start_health_check(self, address: Address):


### PR DESCRIPTION
This PR attempts to solve issue [RLP-892](https://jirainfuy.atlassian.net/browse/RLP-892), which ultimately turned out to be about applying bugfixes to and improving the RIF Comms transport node and client (in the process of investigating the workings of the transport node and message queues).

## Changes

### Major

#### `RIFCommsTransportNode`
This class has been significantly iterated upon.

##### Fields
1. the `_client` field has been renamed to `_comms_client` for greater clarity.
2. ~~the `_our_topic` field has been renamed to `_our_topic_stream`, to better differentiate between this field and `our_topic_thread`.~~  this has now been removed, `.greenlet` already serves this purpose.
3. the `_greenlets` field has been removed, since it served no purpose.
4. the `_stop_event` field initialization has been removed, since the `Runnable` class already does this. references to this now-removed variable have been replaced with references to `stop_event` (which is the `Runnable` field).

##### Methods
1. the `_queueids_to_queues` method has been removed, since it served no purpose.
2. ~~a new `_start_message_listener` function has been added and invoked in the `start` method. its purpose is to start a greenlet which will listen for incoming messages (it also replaces the old `start_listener_thread` function).~~ this is now done inside the `_run` method.
3. `listen_for_messages` has been replaced with `_receive_messages`. this new function now calls the previously unused `_handle_message` function.
4. `_handle_message` has been overhauled:
    - its signature was corrected, since it received the wrong parameters.
    - it now deals with individual messages rather than assuming that a collection of messages is received.
    - the individual `_receive` functions have been replaced for the `_ack_message` function, which sends back a `Delivered` message (unless the received message is also `Delivered`-typed). this also simplifies the previous `if` statement which checked received message types.
    - useless code has been removed.
5. ~~`stop_listener_thread` has been renamed to `_stop_message_listener`, which is symmetric with `_start_message_listener`. its code has also been fixed, which called greenlet functions on the wrong type of variables.~~ this is now done within the `stop` method
6. the `_enqueue_message` code was moved to `enqueue_message` since it was 2 lines long, and only used there.
7. `_parse_topic_new_data` has been renamed to `_notification_to_message` for hopefully greater clarity. it's also now a static method, since it does not use `self`. finally, some of its internal variables have been renamed for clarity's sake.
8. the order of the methods for this class has been changed to match the abstract transport node class, as well as its own internal order of use.

#### `RIFCommsClient`
Some of the methods for this class have had their signatures and/or bodies changed:
  1. `subscribe_to` now receives an `Address` parameter instead of a `str` topic ID, since this conversion is done within the comms client code.
  2. `is_subscribed_to` now returns a `bool` instead of a `BooleanResponse`, which is simpler. it also uses the given parameter differently (more details in the diff).
  3. `send_message` now:
      - receives a `message_payload` first, and then an `rsk_address`. this is changed so that it is more similar to the transport node `send_message` method. 
      - uses the given `payload` parameter to put the `PublishPayload` object together (instead of a test string). 
      - `topic_id`—which was previously a function param—is now internally derived from the given address.
      - returns nothing instead of a `Void`-typed variable.
  4. `unsubscribe_from` now receives an `Address` instead of a `str`. the conversion of this address to a topic ID is done internally within the client. it also returns nothing instead of a `Void`-typed variable.
  5. `disconnect` now has no `return` statement (instead of returning a `Void`-typed variable).

### Minor
- for consistency's sake:
  1. `rif_comms/layer.RifCommsLayer` has been renamed to `rif_comms/layer.Layer`.
  2. `rif_comms/node.RifCommsNode` has been renamed to `rif_comms/node.Node`.
  3. `rif_comms/client.RifCommsClient` has been renamed to `rif_comms/client.Client`.
  (named imports are still used)
- the type hint for the `message` param in `transport/node.py`'s `Node.send_message` method was fixed (`RaidenMessage` → `TransportMessage`).
- truthiness for `Runnable` variables in both the Matrix and RIF Comms transport nodes has been made more explicit: `if queue` → `if queue.greenlet` (`if queue` works due to the `Runnable.__bool__` function, but it's quite obscure).
- RIF Comms docstrings were added and iterated upon, both for the node as well as the client.
- some log texts have been (hopefully) improved.
- some TODOs have been added.
- some `RIFCommsClient` methods have been renamed:
  1. `subscribe` has been renamed to `subscribe_to` for more clarity.
  2. `get_peer_id` has been renamed to be internal, as it is currently used outside of the client code only due to a bug.
  3. `has_subscription` has been renamed to `is_subscribed_to` for more clarity.
- `SignedRetrieableMessage` has been added to the the `__all__` variable in `raiden/messages.py` (a rightful IDE complaint).
- _Reformat Code_ and _Optimize Imports_ have been applied to all modified files.

## TODOs
- [x] verify unit test suite results
- [x] create issues for all the code TODOs (if they don't exist yet)
- [x] manually verify rif comms unit tests