### PR TITLE
RLP-901 Fixing mediated backward payment

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -35,7 +35,8 @@ from raiden.transfer.state import (
     NODE_NETWORK_UNREACHABLE,
     NettingChannelState,
     RouteState,
-    message_identifier_from_prng, NODE_NETWORK_UNKNOWN,
+    message_identifier_from_prng,
+    NODE_NETWORK_UNKNOWN
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -35,7 +35,7 @@ from raiden.transfer.state import (
     NODE_NETWORK_UNREACHABLE,
     NettingChannelState,
     RouteState,
-    message_identifier_from_prng,
+    message_identifier_from_prng, NODE_NETWORK_UNKNOWN,
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
@@ -191,8 +191,9 @@ def filter_reachable_routes(
         node_network_state = nodeaddresses_to_networkstates.get(
             route.node_address, NODE_NETWORK_UNREACHABLE
         )
-
-        if node_network_state == NODE_NETWORK_REACHABLE:
+        # TODO: jonaf2103 NODE_NETWORK_UNKNOWN should be
+        #  removed from this comparison after fixing the reachability issues
+        if node_network_state == NODE_NETWORK_REACHABLE or node_network_state == NODE_NETWORK_UNKNOWN:
             reachable_routes.append(route)
 
     return reachable_routes


### PR DESCRIPTION
## Problem
The mediated payment fails after the mediator is down and goes back again.

### Escenario

FN1 -> FN2 -> FN3

FN1 want's to pay to FN3 through FN2

### Steps to Reproduce

* Setup the escenario
* Make a mediated payment from FN1 to FN3 through FN2
* Make a mediated payment from FN3 to FN1 through FN2
* Pull Down FN2
* Startup FN2
* Make a mediated payment from FN1 to FN3 through FN2
* Make a mediated payment from FN3 to FN1 through FN2

The last payment should fail because the mediator can't reach the FN1

### Cause
The filter function called `filter_reachable_routes` in **raiden/transfer/mediated_transfer/mediator.py:184** was filtering the routes by status NODE_NETWORK_REACHABLE  but we have a problem of reachability on the node so the route between FN1 and FN2 had status NODE_NETWORK_UNKNOWN so it was being filtered out from the list.

### Solution
Since we have several issues of reachability to solve, for now we will filter by NODE_NETWORK_REACHABLE and NODE_NETWORK_UNKNOWN since we don't know if it's reachable or not so we can't assume that is not reachable.

**NOTE: this solution should be temporal until we fix the reachability problems that we have. After that we should remove this, i put a TODO to have this in mind in the future**

#### Changes

* Adding NODE_NETWORK_UNKNOWN to the route filtering since reachability is not working well right now, we should get back to the old filter after fixing the reachability issues that we have

This affects the mediated payments flow.

### TODO

:heavy_check_mark:  - Run baseline to compare results
:heavy_check_mark:  - Test lock expired related issues [RLP-726](https://jirainfuy.atlassian.net/browse/RLP-726) and [RLP-787](https://jirainfuy.atlassian.net/browse/RLP-787)

[Here](https://github.com/rsksmart/lumino/files/5583188/RLP-901.log) the test results, those are ok if you compare with [this](https://github.com/anarancio/lumino-docs/blob/master/unit-testing/results/develop/2020-11-06/summary.txt) baseline.