### PR TITLE
Bugfix/rlp 802/register secret lc

### DIFF
--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,5 +1,5 @@
 const backendUrl='http://localhost:5002'; 
-const nodeAddress = '0x2Cd53d83E5ca1F3c66EDC7bf307139c6B1989C9a'; 
+const nodeAddress = '0x6dd4d8005E5D2DEA818ae4A8d57c8FA1B5c492C8'; 
 const rnsDomain = null 
 const chainEndpoint = 'http://localhost:4444'; 
 

--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,7 +1,7 @@
-const backendUrl='http://localhost:5002';
-const nodeAddress = '0x62Aa1173561C4E92876B3D073B9767A2d07496f8';
-const rnsDomain = null;
-const chainEndpoint = 'http://localhost:4444';
+const backendUrl='http://localhost:5002'; 
+const nodeAddress = '0x2Cd53d83E5ca1F3c66EDC7bf307139c6B1989C9a'; 
+const rnsDomain = null 
+const chainEndpoint = 'http://localhost:4444'; 
 
 window.luminoUrl = backendUrl;
 window.nodeAddress= nodeAddress;

--- a/raiden/api/webui/static/endpointConfig.js
+++ b/raiden/api/webui/static/endpointConfig.js
@@ -1,7 +1,7 @@
-const backendUrl='http://localhost:5002'; 
-const nodeAddress = '0x6dd4d8005E5D2DEA818ae4A8d57c8FA1B5c492C8'; 
-const rnsDomain = null 
-const chainEndpoint = 'http://localhost:4444'; 
+const backendUrl='http://localhost:5002';
+const nodeAddress = '0x62Aa1173561C4E92876B3D073B9767A2d07496f8';
+const rnsDomain = null;
+const chainEndpoint = 'http://localhost:4444';
 
 window.luminoUrl = backendUrl;
 window.nodeAddress= nodeAddress;

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -326,17 +326,20 @@ def handle_channel_closed(raiden: "RaidenService", event: Event):
             raiden.handle_and_track_state_change(channel_closed)
         else:
             # Must be a light client
+            closing_participant = args["closing_participant"]
+            non_closing_participant = channel_state.partner_state.address \
+                if channel_state.our_state.address == closing_participant \
+                else channel_state.our_state.address
             latest_non_closing_balance_proof = LightClientMessageHandler.get_latest_light_client_non_closing_balance_proof(
-                channel_state.identifier, channel_state.our_state.address, raiden.wal.storage
+                channel_state.identifier, non_closing_participant, raiden.wal.storage
             )
             channel_closed = ContractReceiveChannelClosedLight(
                 transaction_hash=transaction_hash,
-                transaction_from=args["closing_participant"],
+                transaction_from=closing_participant,
                 canonical_identifier=channel_state.canonical_identifier,
                 block_number=block_number,
                 block_hash=block_hash,
-                closing_participant=channel_state.partner_state.address,
-                non_closing_participant=channel_state.our_state.address,
+                non_closing_participant=non_closing_participant,
                 latest_update_non_closing_balance_proof_data=latest_non_closing_balance_proof
             )
             raiden.handle_and_track_state_change(channel_closed)

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -327,7 +327,7 @@ def handle_channel_closed(raiden: "RaidenService", event: Event):
         else:
             # Must be a light client
             latest_non_closing_balance_proof = LightClientMessageHandler.get_latest_light_client_non_closing_balance_proof(
-                channel_state.identifier, channel_state.partner_state.address, raiden.wal.storage
+                channel_state.identifier, channel_state.our_state.address, raiden.wal.storage
             )
             channel_closed = ContractReceiveChannelClosedLight(
                 transaction_hash=transaction_hash,
@@ -335,8 +335,8 @@ def handle_channel_closed(raiden: "RaidenService", event: Event):
                 canonical_identifier=channel_state.canonical_identifier,
                 block_number=block_number,
                 block_hash=block_hash,
-                closing_participant=channel_state.our_state.address,
-                non_closing_participant=channel_state.partner_state.address,
+                closing_participant=channel_state.partner_state.address,
+                non_closing_participant=channel_state.our_state.address,
                 latest_update_non_closing_balance_proof_data=latest_non_closing_balance_proof
             )
             raiden.handle_and_track_state_change(channel_closed)

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -33,7 +33,8 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
     ContractReceiveChannelClosedLight,
-    ContractReceiveChannelSettledLight, ContractReceiveSecretRevealLight
+    ContractReceiveChannelSettledLight,
+    ContractReceiveSecretRevealLight
 )
 from raiden.transfer.utils import (
     get_event_with_balance_proof_by_locksroot,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -586,10 +586,10 @@ class RaidenEventHandler(EventHandler):
 
         canonical_identifier = channel_unlock_event.canonical_identifier
         token_network_identifier = canonical_identifier.token_network_address
-        channel_identifier = canonical_identifier.channel_identifier
         participant = channel_unlock_event.participant
 
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
+            creator_address=participant,
             canonical_identifier=canonical_identifier
         )
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -664,24 +664,28 @@ class RaidenEventHandler(EventHandler):
             canonical_identifier=channel_unlock_event.canonical_identifier,
             participant=channel_unlock_event.participant,
             our_address=channel_unlock_event.client)
-        if should_search_events(channel_state):
-            unlock_light(
-                raiden=raiden,
-                chain_state=chain_state,
-                channel_unlock_event=channel_unlock_event,
-                participant=channel_state.partner_state.address,
-                partner=channel_state.our_state.address,
-                end_state=channel_state.our_state
-            )
         if should_search_state_changes(channel_state):
-            unlock_light(
-                raiden=raiden,
-                chain_state=chain_state,
-                channel_unlock_event=channel_unlock_event,
-                participant=channel_state.our_state.address,
-                partner=channel_state.partner_state.address,
-                end_state=channel_state.partner_state
-            )
+            gain = get_batch_unlock_gain(channel_state)
+            if gain.from_partner_locks > 0:
+                unlock_light(
+                    raiden=raiden,
+                    chain_state=chain_state,
+                    channel_unlock_event=channel_unlock_event,
+                    participant=channel_state.our_state.address,
+                    partner=channel_state.partner_state.address,
+                    end_state=channel_state.partner_state
+                )
+        if should_search_events(channel_state):
+            gain = get_batch_unlock_gain(channel_state)
+            if gain.from_our_locks > 0:
+                unlock_light(
+                    raiden=raiden,
+                    chain_state=chain_state,
+                    channel_unlock_event=channel_unlock_event,
+                    participant=channel_state.partner_state.address,
+                    partner=channel_state.our_state.address,
+                    end_state=channel_state.our_state
+                )
 
     @staticmethod
     def handle_contract_send_channelsettle(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -17,7 +17,6 @@ from raiden.messages import RequestRegisterSecret, UnlockLightRequest, Settlemen
 from raiden.network.proxies.payment_channel import PaymentChannel
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.resolver.client import reveal_secret_with_resolver
-from raiden.storage.restore import channel_state_until_state_change
 from raiden.transfer import views
 from raiden.transfer.architecture import Event
 from raiden.transfer.balance_proof import pack_balance_proof_update
@@ -64,8 +63,6 @@ from raiden.transfer.unlock import get_channel_state, should_search_events, shou
 from raiden.transfer.utils import (
     get_event_with_balance_proof_by_balance_hash,
     get_state_change_with_balance_proof_by_balance_hash,
-    get_state_change_with_balance_proof_by_locksroot,
-    get_event_with_balance_proof_by_locksroot,
 )
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner
 from raiden.utils import pex

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -664,25 +664,28 @@ class RaidenEventHandler(EventHandler):
             canonical_identifier=channel_unlock_event.canonical_identifier,
             participant=channel_unlock_event.participant,
             our_address=channel_unlock_event.client)
-        if should_search_events(channel_state):
-            unlock_light(
-                raiden=raiden,
-                chain_state=chain_state,
-                channel_unlock_event=channel_unlock_event,
-                participant=channel_state.partner_state.address,
-                partner=channel_state.our_state.address,
-                end_state=channel_state.our_state
-            )
         if should_search_state_changes(channel_state):
-            unlock_light(
-                raiden=raiden,
-                chain_state=chain_state,
-                channel_unlock_event=channel_unlock_event,
-                participant=channel_state.our_state.address,
-                partner=channel_state.partner_state.address,
-                end_state=channel_state.partner_state
-            )
-
+            gain = get_batch_unlock_gain(channel_state)
+            if gain.from_partner_locks > 0:
+                unlock_light(
+                    raiden=raiden,
+                    chain_state=chain_state,
+                    channel_unlock_event=channel_unlock_event,
+                    participant=channel_state.our_state.address,
+                    partner=channel_state.partner_state.address,
+                    end_state=channel_state.partner_state
+                )
+        if should_search_events(channel_state):
+            gain = get_batch_unlock_gain(channel_state)
+            if gain.from_our_locks > 0:
+                unlock_light(
+                    raiden=raiden,
+                    chain_state=chain_state,
+                    channel_unlock_event=channel_unlock_event,
+                    participant=channel_state.partner_state.address,
+                    partner=channel_state.our_state.address,
+                    end_state=channel_state.our_state
+                )
     @staticmethod
     def handle_contract_send_channelsettle(
         raiden: "RaidenService", channel_settle_event: ContractSendChannelSettle

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -7,7 +7,7 @@ from raiden.messages import RevealSecret, Unlock, Message, SecretRequest, LockEx
 from raiden.transfer.architecture import Event, SendMessageEvent
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
-from raiden.transfer.state import BalanceProofUnsignedState
+from raiden.transfer.state import BalanceProofUnsignedState, balanceproof_from_envelope
 from raiden.utils import pex, sha3
 from raiden.utils.serialization import deserialize_secret, deserialize_secret_hash, serialize_bytes
 from raiden.utils.typing import (
@@ -181,7 +181,7 @@ class SendLockExpiredLight(SendMessageEvent):
 
     def __repr__(self) -> str:
         return "<SendLockExpiredLight msgid:{} secrethash:{} recipient:{}>".format(
-            self.message_identifier,  pex(self.secrethash), pex(self.recipient)
+            self.message_identifier, pex(self.secrethash), pex(self.recipient)
         )
 
     def __eq__(self, other: Any) -> bool:
@@ -298,19 +298,7 @@ class SendLockedTransferLight(SendMessageEvent):
         super().__init__(recipient, channel_identifier, message_identifier)
 
         self.signed_locked_transfer = signed_locked_transfer
-
-        canonical_identifier = CanonicalIdentifier(
-            channel_identifier=channel_identifier,
-            token_network_address=self.signed_locked_transfer.token_network_address,
-            chain_identifier=self.signed_locked_transfer.chain_id
-        )
-        self.balance_proof = BalanceProofUnsignedState(
-            nonce=self.signed_locked_transfer.nonce,
-            transferred_amount=self.signed_locked_transfer.transferred_amount,
-            locked_amount=self.signed_locked_transfer.locked_amount,
-            locksroot=self.signed_locked_transfer.locksroot,
-            canonical_identifier=canonical_identifier
-        )
+        self.balance_proof = balanceproof_from_envelope(signed_locked_transfer)
 
     def __repr__(self) -> str:
         return "<SendLockedTransferLight msgid:{} signed_locked_transfer:{} recipient:{}>".format(

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -5,7 +5,6 @@ from raiden.lightclient.models.light_client_protocol_message import LightClientP
 from raiden.messages import RevealSecret, Unlock, Message, SecretRequest, LockExpired, LockedTransfer
 
 from raiden.transfer.architecture import Event, SendMessageEvent
-from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.state import BalanceProofUnsignedState, balanceproof_from_envelope
 from raiden.utils import pex, sha3

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -4,7 +4,7 @@ from eth_utils import to_canonical_address
 
 from raiden.constants import MAXIMUM_PENDING_TRANSFERS
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
-from raiden.messages import LockedTransfer, Unlock
+from raiden.messages import LockedTransfer, Unlock, RevealSecret
 from raiden.settings import DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
@@ -32,7 +32,8 @@ from raiden.transfer.state import (
     NettingChannelState,
     RouteState,
     message_identifier_from_prng)
-from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, StateChange
+from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, StateChange, \
+    ContractReceiveSecretRevealLight
 from raiden.transfer.utils import is_valid_secret_reveal
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
@@ -721,6 +722,78 @@ def handle_onchain_secretreveal(
     return iteration
 
 
+def handle_onchain_secretreveal_light(
+    initiator_state: InitiatorTransferState,
+    state_change: ContractReceiveSecretRevealLight,
+    channel_state: NettingChannelState,
+    pseudo_random_generator: random.Random,
+) -> TransitionResult[InitiatorTransferState]:
+    """ When a secret is revealed on-chain all nodes learn the secret.
+
+    This check the on-chain secret corresponds to the one used by the
+    initiator, and if valid a new balance proof is sent to the next hop with
+    the current lock removed from the merkle tree and the transferred amount
+    updated.
+
+    iteration: TransitionResult[InitiatorTransferState]
+    secret = state_change.secret
+    secrethash = initiator_state.transfer_description.secrethash
+    is_valid_secret = is_valid_secret_reveal(
+        state_change=state_change, transfer_secrethash=secrethash, secret=secret
+    )
+    is_channel_open = channel.get_status(channel_state) == CHANNEL_STATE_OPENED
+    is_lock_expired = state_change.block_number > initiator_state.transfer.lock.expiration
+
+    is_lock_unlocked = is_valid_secret and not is_lock_expired
+
+    if is_lock_unlocked:
+        channel.register_onchain_secret(
+            channel_state=channel_state,
+            secret=secret,
+            secrethash=secrethash,
+            secret_reveal_block_number=state_change.block_number,
+        )
+
+    if is_lock_unlocked and is_channel_open:
+        unlock_events = events_for_unlock_base(
+            initiator_state=initiator_state,
+            channel_state=channel_state,
+            secret=state_change.secret,
+        )
+
+        transfer_description = initiator_state.transfer_description
+
+        message_identifier = message_identifier_from_prng(pseudo_random_generator)
+        unlock_lock = channel.send_unlock(
+            channel_state=channel_state,
+            message_identifier=message_identifier,
+            payment_identifier=transfer_description.payment_identifier,
+            secret=state_change.secret,
+            secrethash=state_change.secrethash,
+        )
+        unlock_msg = Unlock.from_event(unlock_lock)
+        reveal_secret = RevealSecret(secret=state_change.secret, message_identifier=message_identifier_from_prng(pseudo_random_generator))
+        store_received_secret_reveal_event = StoreMessageEvent(message_id=reveal_secret.message_identifier,
+                                                               payment_id=transfer_description.payment_identifier,
+                                                               message_order=9,
+                                                               message=reveal_secret,
+                                                               is_signed=True,
+                                                               message_type=LightClientProtocolMessageType.PaymentSuccessful,
+                                                               light_client_address=transfer_description.initiator)
+        store_created_unlock_event = StoreMessageEvent(message_id=message_identifier,
+                                                       payment_id=transfer_description.payment_identifier,
+                                                       message_order=11,
+                                                       message=unlock_msg,
+                                                       is_signed=False,
+                                                       message_type=LightClientProtocolMessageType.PaymentSuccessful,
+                                                       light_client_address=transfer_description.initiator)
+        events = [store_received_secret_reveal_event, store_created_unlock_event] + unlock_events
+        return TransitionResult(None, events)
+
+    """
+    return TransitionResult(initiator_state, [])
+
+
 def state_transition(
     initiator_state: InitiatorTransferState,
     state_change: StateChange,
@@ -755,6 +828,11 @@ def state_transition(
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
         iteration = handle_onchain_secretreveal(
+            initiator_state, state_change, channel_state, pseudo_random_generator
+        )
+    elif type(state_change) == ContractReceiveSecretRevealLight:
+        assert isinstance(state_change, ContractReceiveSecretRevealLight), MYPY_ANNOTATION
+        iteration = handle_onchain_secretreveal_light(
             initiator_state, state_change, channel_state, pseudo_random_generator
         )
     elif type(state_change) == ActionSendSecretRevealLight:

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -734,7 +734,7 @@ def handle_onchain_secretreveal_light(
     initiator, and if valid a new balance proof is sent to the next hop with
     the current lock removed from the merkle tree and the transferred amount
     updated.
-
+    """
     iteration: TransitionResult[InitiatorTransferState]
     secret = state_change.secret
     secrethash = initiator_state.transfer_description.secrethash
@@ -789,8 +789,7 @@ def handle_onchain_secretreveal_light(
                                                        light_client_address=transfer_description.initiator)
         events = [store_received_secret_reveal_event, store_created_unlock_event] + unlock_events
         return TransitionResult(None, events)
-
-    """
+        
     return TransitionResult(initiator_state, [])
 
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -254,7 +254,7 @@ def try_new_route_light(
             reason="none of the available routes could be used",
         )
         events.append(transfer_failed)
-R
+
         initiator_state = None
 
     else:

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -4,7 +4,7 @@ from eth_utils import to_canonical_address
 
 from raiden.constants import MAXIMUM_PENDING_TRANSFERS
 from raiden.lightclient.models.light_client_protocol_message import LightClientProtocolMessageType
-from raiden.messages import LockedTransfer, Unlock, RevealSecret
+from raiden.messages import LockedTransfer, Unlock
 from raiden.settings import DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
@@ -730,10 +730,8 @@ def handle_onchain_secretreveal_light(
 ) -> TransitionResult[InitiatorTransferState]:
     """ When a secret is revealed on-chain all nodes learn the secret.
 
-    This check the on-chain secret corresponds to the one used by the
-    initiator, and if valid a new balance proof is sent to the next hop with
-    the current lock removed from the merkle tree and the transferred amount
-    updated.
+    This checks that the on-chain secret corresponds to the one used by the
+    initiator.
     """
     iteration: TransitionResult[InitiatorTransferState]
     secret = state_change.secret

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -26,8 +26,13 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretRequest,
     ReceiveSecretReveal,
     ActionTransferReroute,
-    ActionInitInitiatorLight, ReceiveSecretRequestLight, ActionSendSecretRevealLight, ReceiveSecretRevealLight,
-    ReceiveTransferCancelRoute, StoreRefundTransferLight)
+    ActionInitInitiatorLight,
+    ReceiveSecretRequestLight,
+    ActionSendSecretRevealLight,
+    ReceiveSecretRevealLight,
+    ReceiveTransferCancelRoute,
+    StoreRefundTransferLight
+)
 from raiden.transfer.state import RouteState
 from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal, \
     ContractReceiveSecretRevealLight
@@ -39,7 +44,8 @@ from raiden.utils.typing import (
     Optional,
     SecretHash,
     TokenNetworkID,
-    cast, Union,
+    cast,
+    Union
 )
 
 
@@ -753,20 +759,9 @@ def state_transition(
             channelidentifiers_to_channels=channelidentifiers_to_channels,
             pseudo_random_generator=pseudo_random_generator,
         )
-    elif type(state_change) == ContractReceiveSecretReveal:
-        assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
-        msg = "ContractReceiveSecretReveal should be accompanied by a valid payment state"
-        assert payment_state, msg
-        iteration = handle_onchain_secretreveal(
-            payment_state=payment_state,
-            state_change=state_change,
-            channelidentifiers_to_channels=channelidentifiers_to_channels,
-            pseudo_random_generator=pseudo_random_generator,
-        )
-    elif type(state_change) == ContractReceiveSecretRevealLight:
-        assert isinstance(state_change, ContractReceiveSecretRevealLight), MYPY_ANNOTATION
-        msg = "ContractReceiveSecretRevealLight should be accompanied by a valid payment state"
-        assert payment_state, msg
+    elif type(state_change) == ContractReceiveSecretReveal or type(state_change) == ContractReceiveSecretRevealLight:
+        assert payment_state, "ContractReceiveSecretReveal and ContractReceiveSecretRevealLight " \
+                              "should be accompanied by a valid payment state"
         iteration = handle_onchain_secretreveal(
             payment_state=payment_state,
             state_change=state_change,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -29,7 +29,8 @@ from raiden.transfer.mediated_transfer.state_change import (
     ActionInitInitiatorLight, ReceiveSecretRequestLight, ActionSendSecretRevealLight, ReceiveSecretRevealLight,
     ReceiveTransferCancelRoute, StoreRefundTransferLight)
 from raiden.transfer.state import RouteState
-from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal
+from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal, \
+    ContractReceiveSecretRevealLight
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     BlockNumber,
@@ -38,7 +39,7 @@ from raiden.utils.typing import (
     Optional,
     SecretHash,
     TokenNetworkID,
-    cast,
+    cast, Union,
 )
 
 
@@ -489,7 +490,7 @@ def handle_offchain_secretreveal(
 
 def handle_onchain_secretreveal(
     payment_state: InitiatorPaymentState,
-    state_change: ContractReceiveSecretReveal,
+    state_change: Union[ContractReceiveSecretReveal, ContractReceiveSecretRevealLight],
     channelidentifiers_to_channels: ChannelMap,
     pseudo_random_generator: random.Random,
 ) -> TransitionResult[InitiatorPaymentState]:
@@ -745,6 +746,26 @@ def state_transition(
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
         msg = "ContractReceiveSecretReveal should be accompanied by a valid payment state"
+        assert payment_state, msg
+        iteration = handle_onchain_secretreveal(
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
+        )
+    elif type(state_change) == ContractReceiveSecretReveal:
+        assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
+        msg = "ContractReceiveSecretReveal should be accompanied by a valid payment state"
+        assert payment_state, msg
+        iteration = handle_onchain_secretreveal(
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
+        )
+    elif type(state_change) == ContractReceiveSecretRevealLight:
+        assert isinstance(state_change, ContractReceiveSecretRevealLight), MYPY_ANNOTATION
+        msg = "ContractReceiveSecretRevealLight should be accompanied by a valid payment state"
         assert payment_state, msg
         iteration = handle_onchain_secretreveal(
             payment_state=payment_state,

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -494,7 +494,7 @@ def handle_onchain_secretreveal(
     state_change: Union[ContractReceiveSecretReveal, ContractReceiveSecretRevealLight],
     channel_state: NettingChannelState,
 ) -> TransitionResult[TargetTransferState]:
-    """ Validates and handles a ContractReceiveSecretReveal state change.
+    """ Validates and handles a ContractReceiveSecretReveal state change. """
     valid_secret = is_valid_secret_reveal(
         state_change=state_change,
         transfer_secrethash=target_state.transfer.lock.secrethash,
@@ -511,7 +511,6 @@ def handle_onchain_secretreveal(
 
         target_state.state = TargetTransferState.ONCHAIN_UNLOCK
         target_state.secret = state_change.secret
-    """
     return TransitionResult(target_state, list())
 
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -758,9 +758,7 @@ def state_transition(
         assert target_state, msg
         iteration = handle_onchain_secretreveal(target_state, state_change, channel_state)
     elif type(state_change) == ContractReceiveSecretRevealLight:
-        assert isinstance(state_change, ContractReceiveSecretRevealLight), MYPY_ANNOTATION
-        msg = "ContractReceiveSecretReveal should be accompanied by a valid target state"
-        assert target_state, msg
+        assert target_state, "ContractReceiveSecretReveal should be accompanied by a valid target state"
         iteration = handle_onchain_secretreveal(target_state, state_change, channel_state)
     elif type(state_change) == ReceiveUnlock:
         assert isinstance(state_change, ReceiveUnlock), MYPY_ANNOTATION

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -764,13 +764,13 @@ def handle_secret_reveal(
 
 
 def handle_contract_secret_reveal(
-    chain_state: ChainState, state_change: ContractReceiveSecretReveal, storage=None
+    chain_state: ChainState, state_change: ContractReceiveSecretReveal
 ) -> TransitionResult[ChainState]:
     return subdispatch_to_paymenttask(chain_state, state_change, chain_state.our_address, state_change.secrethash)
 
 
 def handle_contract_secret_reveal_light(
-    chain_state: ChainState, state_change: ContractReceiveSecretRevealLight, storage=None
+    chain_state: ChainState, state_change: ContractReceiveSecretRevealLight
 ) -> TransitionResult[ChainState]:
     return subdispatch_to_paymenttask(chain_state, state_change, state_change.lc_address, state_change.secrethash)
 
@@ -1043,10 +1043,10 @@ def handle_state_change(
         iteration = handle_token_network_action(chain_state, state_change)
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
-        iteration = handle_contract_secret_reveal(chain_state, state_change, storage)
+        iteration = handle_contract_secret_reveal(chain_state, state_change)
     elif type(state_change) == ContractReceiveSecretRevealLight:
         assert isinstance(state_change, ContractReceiveSecretRevealLight), MYPY_ANNOTATION
-        iteration = handle_contract_secret_reveal_light(chain_state, state_change, storage)
+        iteration = handle_contract_secret_reveal_light(chain_state, state_change)
     elif type(state_change) == ContractReceiveUpdateTransfer:
         assert isinstance(state_change, ContractReceiveUpdateTransfer), MYPY_ANNOTATION
         iteration = handle_token_network_action(chain_state, state_change)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -445,7 +445,6 @@ class ContractReceiveChannelClosedLight(ContractReceiveStateChange):
         canonical_identifier: CanonicalIdentifier,
         block_number: BlockNumber,
         block_hash: BlockHash,
-        closing_participant: Address,
         non_closing_participant: Address,
         latest_update_non_closing_balance_proof_data: LightClientNonClosingBalanceProof
     ) -> None:
@@ -453,9 +452,12 @@ class ContractReceiveChannelClosedLight(ContractReceiveStateChange):
 
         self.transaction_from = transaction_from
         self.canonical_identifier = canonical_identifier
-        self.closing_participant = closing_participant
         self.non_closing_participant = non_closing_participant
         self.latest_update_non_closing_balance_proof_data = latest_update_non_closing_balance_proof_data
+
+    @property
+    def closing_participant(self) -> Address:
+        return self.transaction_from
 
     @property
     def channel_identifier(self) -> ChannelID:

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1083,6 +1083,77 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
         )
 
 
+class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
+    """ A new secret was registered with the SecretRegistry contract. """
+
+    def __init__(
+        self,
+        transaction_hash: TransactionHash,
+        secret_registry_address: SecretRegistryAddress,
+        secrethash: SecretHash,
+        secret: Secret,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+    ) -> None:
+        if not isinstance(secret_registry_address, T_SecretRegistryAddress):
+            raise ValueError("secret_registry_address must be of type SecretRegistryAddress")
+        if not isinstance(secrethash, T_SecretHash):
+            raise ValueError("secrethash must be of type SecretHash")
+        if not isinstance(secret, T_Secret):
+            raise ValueError("secret must be of type Secret")
+
+        super().__init__(transaction_hash, block_number, block_hash)
+
+        self.secret_registry_address = secret_registry_address
+        self.secrethash = secrethash
+        self.secret = secret
+
+    def __repr__(self) -> str:
+        return (
+            "<ContractReceiveSecretRevealLight"
+            " secret_registry:{} secrethash:{} secret:{} block:{}"
+            ">"
+        ).format(
+            pex(self.secret_registry_address),
+            pex(self.secrethash),
+            pex(self.secret),
+            self.block_number,
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ContractReceiveSecretRevealLight)
+            and self.secret_registry_address == other.secret_registry_address
+            and self.secrethash == other.secrethash
+            and self.secret == other.secret
+            and super().__eq__(other)
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "transaction_hash": serialize_bytes(self.transaction_hash),
+            "secret_registry_address": to_checksum_address(self.secret_registry_address),
+            "secrethash": serialize_bytes(self.secrethash),
+            "secret": serialize_bytes(self.secret),
+            "block_number": str(self.block_number),
+            "block_hash": serialize_bytes(self.block_hash),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContractReceiveSecretRevealLight":
+        return cls(
+            transaction_hash=deserialize_transactionhash(data["transaction_hash"]),
+            secret_registry_address=to_canonical_address(data["secret_registry_address"]),
+            secrethash=deserialize_secret_hash(data["secrethash"]),
+            secret=deserialize_secret(data["secret"]),
+            block_number=BlockNumber(int(data["block_number"])),
+            block_hash=BlockHash(deserialize_bytes(data["block_hash"])),
+        )
+
+
 class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     """ All the locks were claimed via the blockchain.
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1094,6 +1094,7 @@ class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
         secret: Secret,
         block_number: BlockNumber,
         block_hash: BlockHash,
+        lc_address: Address
     ) -> None:
         if not isinstance(secret_registry_address, T_SecretRegistryAddress):
             raise ValueError("secret_registry_address must be of type SecretRegistryAddress")
@@ -1107,16 +1108,18 @@ class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
         self.secret_registry_address = secret_registry_address
         self.secrethash = secrethash
         self.secret = secret
+        self.lc_address = lc_address
 
     def __repr__(self) -> str:
         return (
             "<ContractReceiveSecretRevealLight"
-            " secret_registry:{} secrethash:{} secret:{} block:{}"
+            " secret_registry:{} secrethash:{} secret:{} block:{} lc_address:{}"
             ">"
         ).format(
             pex(self.secret_registry_address),
             pex(self.secrethash),
             pex(self.secret),
+            pex(self.lc_address),
             self.block_number,
         )
 
@@ -1126,6 +1129,7 @@ class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
             and self.secret_registry_address == other.secret_registry_address
             and self.secrethash == other.secrethash
             and self.secret == other.secret
+            and self.lc_address == other.lc_address
             and super().__eq__(other)
         )
 
@@ -1140,6 +1144,7 @@ class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
             "secret": serialize_bytes(self.secret),
             "block_number": str(self.block_number),
             "block_hash": serialize_bytes(self.block_hash),
+            "lc_address": to_checksum_address(self.lc_address),
         }
 
     @classmethod
@@ -1151,6 +1156,7 @@ class ContractReceiveSecretRevealLight(ContractReceiveStateChange):
             secret=deserialize_secret(data["secret"]),
             block_number=BlockNumber(int(data["block_number"])),
             block_hash=BlockHash(deserialize_bytes(data["block_hash"])),
+            lc_address=to_canonical_address(data["lc_address"]),
         )
 
 


### PR DESCRIPTION
## What does this commit solves?
On chain unlock in mediated payments was not working in a Taringa-like architecture. 

## How does it solves it?

If applied, this commit will:
- **Exchange** closing/non-closing participant addresses in the channel closed event handler in order to send the right balance proof
- **Remove** channel restoration when unlocking, to prevent wrong participant from unlocking locked transfers
- **Check** if the light client will have any gain unlocking, instead of always unlocking 
- **Add** light client handler for on chain secret reveal, as the gain of a participant is not the same if a secret is registered or not
- **Add** the balance proof as a property to SendLockedTransferLight class to prevent a crash when settling a channel from a initiator. hwn the payment was not completed off chain