### PR TITLE
RLP-916: fix pyOpenSSL dependency

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -52,6 +52,7 @@ py-geth==2.1.0
 py-solc==3.2.0
 pycparser==2.18
 pycryptodome==3.6.6
+pyOpenSSL==19.1.0
 pysha3==1.0.2
 pystun-patched-for-raiden==0.1.0
 pytoml==0.1.19


### PR DESCRIPTION
## Background
A new version for the `pyOpenSSL` library has been [recently released](https://pypi.org/project/pyOpenSSL/20.0.0/).

This does not exist as an **explicit** dependency in our requirements, so the latest stable version of this library is fetched and installed automatically (and installed _indirectly_ from our `requirements.txt` file).

## Problem
Unfortunately, this latest version is not compatible with the current Lumino code.

## Solution
`pyOpenSSL==19.1.10` was added as a new constraint. This is the latest version known to work correctly with the system.