### PR TITLE
RLP-849: iterate RIF comms tests

### DIFF
--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -1,13 +1,9 @@
-import json
 import unittest
 
-import grpc
 import pytest
 from eth_utils import to_canonical_address
 from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.node import Node as RIFCommsNode
-from transport.rif_comms.proto.api_pb2 import Channel, PublishPayload, Msg
-from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
 test_nodes = dict([
     (1, {
@@ -53,14 +49,13 @@ def rif_comms_client(request):
 @pytest.mark.usefixtures("rif_comms_client")
 class TestRIFCommsClient(unittest.TestCase):
     """
-    Test for RIFCommsClient. This class is for test the basic operations of the client.
+    Test class for RIFCommsClient. It covers the basic operations of the client.
 
-    How to use it:
-
-    - modify the test_nodes address and rif_comms_api fields
+    How to use:
+    - modify the `address and `comms-api` fields for the `test_nodes` variable
     - addresses are used as representations of the Lumino keystore
     - each of the nodes is used as a separate peer
-    - all tests assume that there is a RIF COMMS node already running
+    - all tests assume that there is a RIF Comms node already running
     """
 
     @pytest.mark.skip(reason="succeeds no matter what")
@@ -122,51 +117,6 @@ class TestRIFCommsClient(unittest.TestCase):
         peer_id = self.client_1._get_peer_id(self.address_1)
         self.client_1.disconnect()
         # TODO check if end comms deletes topics
-
-    @pytest.mark.skip(reason="fails due to as-of-yet undetermined reason, used to work")
-    def test_send_lumino_message(self):
-        # this test requires a lumino node started with a comms api matching test_nodes[1]["comms_api"]
-        stub = CommunicationsApiStub(grpc.insecure_channel(self.api_1))
-
-        # TODO: obtain this programmatically
-        channel_id = "16Uiu2HAmQmHFGepf3eaptGCkPhhw8ggipsrJzZyLTrnd5TJKWDHk"
-        # got this from subscription of lumino node
-
-        sub = stub.Subscribe(Channel(channelId=channel_id))
-        print("sub")
-
-        some_raiden_message = {
-            'type': 'LockedTransfer',
-            'chain_id': 33,
-            'message_identifier': 9074731958492744333,
-            'payment_identifier': 2958725218135700941,
-            'payment_hash_invoice': '0x0000000000000000000000000000000000000000000000000000000000000000',
-            'nonce': 45,
-            'token_network_address': '0xd548700d98f32f83b3c88756cf340b7f61877d75',
-            'token': '0xf563b16dc42d9cb6d7ca31793f2d62131d586d05',
-            'channel_identifier': 12,
-            'transferred_amount': 17000000000000000000,
-            'locked_amount': 1000000000000000000,
-            'recipient': '0x00e8249ee607ea67127c4add69291a6c412603c5',
-            'locksroot': '0x043c092c72059c4c154cb342409d95364888a98fa87efadece5add9c255dce9a',
-            'lock': {
-                'type': 'Lock',
-                'amount': 1000000000000000000,
-                'expiration': 1165251,
-                'secrethash': '0x2dc5a7ff26be395d443200db5d16b5d2aadae3a83836be648cd4cba8e2e555fe'
-            },
-            'target': '0x00e8249ee607ea67127c4add69291a6c412603c5',
-            'initiator': '0x27633dc87378a551f09f2fcf43a48fc2b3425d43',
-            'fee': 0,
-            'signature': '0xbaa4df61ab23ab8fdddf4a90fd5db7dd04da364795ebb717426bdd1fcefb411759e1b41d71c3c54b2a75c3eba0f2a2c54c846a0139120ee794f51b0e2a0d954d1c'
-        }
-
-        stub.SendMessageToTopic(
-            PublishPayload(
-                topic=Channel(channelId=channel_id),
-                message=Msg(payload=str.encode(json.dumps(some_raiden_message)))
-            )
-        )
 
     @pytest.mark.skip(reason="hangs when attempting to sub to a node without it having subbed to itself first")
     def test_two_clients_cross_messaging_same_topic(self):

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 from eth_utils import to_canonical_address
 from transport.rif_comms.client import Client as RIFCommsClient
-from transport.rif_comms.node import Node as RIFCommsNode
+from transport.rif_comms.utils import notification_to_payload
 
 test_nodes = dict([
     (1, {
@@ -135,11 +135,11 @@ class TestRIFCommsClient(unittest.TestCase):
         self.client_2.send_message(payload_2, self.address_1)
 
         for resp in one_sub_two:
-            received_message = RIFCommsNode._notification_to_message(resp)
+            received_message = notification_to_payload(resp)
             assert received_message == payload_1
             break  # only 1 message is expected
 
         for resp in two_sub_one:
-            received_message = RIFCommsNode._notification_to_message(resp)
+            received_message = notification_to_payload(resp)
             assert received_message == payload_2
             break  # only 1 message is expected

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -99,7 +99,7 @@ class TestRIFCommsClient(unittest.TestCase):
         # register node 1, get own peer id, disconnect
         notification = self.client_1.connect()
         peer_id = self.client_1._get_peer_id(self.address_1)
-        self.rif_comms_client.disconnect()
+        self.client_1.disconnect()
         # TODO check if end comms deletes topics
 
     @pytest.mark.skip(reason="ignore")

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -5,20 +5,20 @@ from eth_utils import to_canonical_address
 from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.utils import notification_to_payload
 
-test_nodes = dict([
-    (1, {
+test_nodes = {
+    1: {
         "address": to_canonical_address("0x8cb891510dF75C223C53f910A98c3b61B9083c3B"),
         "comms-api": "localhost:5013",
-    }),
-    (2, {
+    },
+    2: {
         "address": to_canonical_address("0xeBfF0EEe8E2b6952E589B0475e3F0E34dA0655B1"),
         "comms-api": "localhost:6013",
-    }),
-    (3, {
+    },
+    3: {
         "address": to_canonical_address("0x636BA79E46E0594ECbbEBb4F74B9336Fd4454442"),
         "comms-api": "localhost:7013",
-    }),
-])
+    },
+}
 
 
 @pytest.mark.usefixtures("rif_comms_client")

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -62,18 +62,18 @@ class TestRIFCommsClient(unittest.TestCase):
     - all tests assume that there is a RIF COMMS node already running
     """
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="succeeds no matter what")
     def test_connect(self):
         response = self.client_1.connect()
         assert response is not None
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="fails without the response assignment")
     def test_locate_own_peer_id(self):
         # register node 1, locate node 1
         response = self.client_1.connect()
         assert self.client_1._get_peer_id(self.address_1) is not ""
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="causes ERR_NO_PEERS_IN_ROUTING_TABLE in comms node although it passes")
     def test_locate_unregistered_peer_id(self):
         # register node 1, locate node 2
         response = self.client_1.connect()
@@ -96,6 +96,23 @@ class TestRIFCommsClient(unittest.TestCase):
         assert self.client_1.is_subscribed_to(self.address_2) is True
         assert self.client_2.is_subscribed_to(self.address_2) is False
         assert self.client_2.is_subscribed_to(self.address_2) is False
+
+    @pytest.mark.skip(reason="ignore")
+    def test_two_clients_cross_subscription(self):
+        # register nodes 1 and 2
+        notification_1 = self.client_1.connect()
+        notification_2 = self.client_2.connect()
+
+        # subscribe to 1 and 2 on both nodes
+        self.client_1.subscribe_to(self.address_1)
+        self.client_1.subscribe_to(self.address_2)
+        self.client_2.subscribe_to(self.address_1)
+        self.client_2.subscribe_to(self.address_2)
+
+        assert self.client_1.is_subscribed_to(self.address_1) is True
+        assert self.client_1.is_subscribed_to(self.address_2) is True
+        assert self.client_2.is_subscribed_to(self.address_1) is True
+        assert self.client_2.is_subscribed_to(self.address_2) is True
 
     @pytest.mark.skip(reason="ignore")
     def test_disconnect(self):
@@ -149,23 +166,6 @@ class TestRIFCommsClient(unittest.TestCase):
                 message=Msg(payload=str.encode(json.dumps(some_raiden_message)))
             )
         )
-
-    @pytest.mark.skip(reason="ignore")
-    def test_two_clients_cross_subscription(self):
-        # register nodes 1 and 2
-        notification_1 = self.client_1.connect()
-        notification_2 = self.client_2.connect()
-
-        # subscribe to 1 and 2 on both nodes
-        self.client_1.subscribe_to(self.address_1)
-        self.client_1.subscribe_to(self.address_2)
-        self.client_2.subscribe_to(self.address_1)
-        self.client_2.subscribe_to(self.address_2)
-
-        assert self.client_1.is_subscribed_to(self.address_1) is True
-        assert self.client_1.is_subscribed_to(self.address_2) is True
-        assert self.client_2.is_subscribed_to(self.address_1) is True
-        assert self.client_2.is_subscribed_to(self.address_2) is True
 
     @pytest.mark.skip(reason="ignore")
     def test_two_clients_cross_messaging_same_topic(self):

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -11,15 +11,15 @@ from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 test_nodes = [
     {
         "address": to_canonical_address("0x8cb891510dF75C223C53f910A98c3b61B9083c3B"),
-        "comms_api": "localhost:5013",
+        "comms-api": "localhost:5013",
     },
     {
         "address": to_canonical_address("0xeBfF0EEe8E2b6952E589B0475e3F0E34dA0655B1"),
-        "comms_api": "localhost:5016",
+        "comms-api": "localhost:5016",
     },
     {
         "address": to_canonical_address("0x636BA79E46E0594ECbbEBb4F74B9336Fd4454442"),
-        "comms_api": "localhost:5019",
+        "comms-api": "localhost:5019",
     },
 ]
 
@@ -65,13 +65,13 @@ class TestRIFCommsClient(unittest.TestCase):
     @pytest.mark.skip(reason="ignore")
     def test_connect(self):
         response = self.client_1.connect()
-        assert self.client_1 is not None
+        assert response is not None
 
     @pytest.mark.skip(reason="ignore")
     def test_locate_own_peer_id(self):
         # register node 1, locate node 1
         response = self.client_1.connect()
-        assert self.client_2._get_peer_id(self.address_1) is not ""
+        assert self.client_1._get_peer_id(self.address_1) is not ""
 
     @pytest.mark.skip(reason="ignore")
     def test_locate_unregistered_peer_id(self):

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -15,11 +15,11 @@ test_nodes = dict([
     }),
     (2, {
         "address": to_canonical_address("0xeBfF0EEe8E2b6952E589B0475e3F0E34dA0655B1"),
-        "comms-api": "localhost:5016",
+        "comms-api": "localhost:6013",
     }),
     (3, {
         "address": to_canonical_address("0x636BA79E46E0594ECbbEBb4F74B9336Fd4454442"),
-        "comms-api": "localhost:5019",
+        "comms-api": "localhost:7013",
     }),
 ])
 
@@ -88,11 +88,14 @@ class TestRIFCommsClient(unittest.TestCase):
 
     @pytest.mark.skip(reason="ignore")
     def test_has_subscriber(self):
-        # register nodes 1 and 2, subscribe from 1 to 2, check subscription
+        # register nodes 1 and 2, subscribe from 1 to 2, check subscriptions
         notification_1 = self.client_1.connect()
         notification_2 = self.client_2.connect()
-        self.client_1.subscribe_to(self.address_2)
+        _, _ = self.client_1.subscribe_to(self.address_2)
+        assert self.client_1.is_subscribed_to(self.address_1) is False
         assert self.client_1.is_subscribed_to(self.address_2) is True
+        assert self.client_2.is_subscribed_to(self.address_2) is False
+        assert self.client_2.is_subscribed_to(self.address_2) is False
 
     @pytest.mark.skip(reason="ignore")
     def test_disconnect(self):

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -79,14 +79,14 @@ class TestRIFCommsClient(unittest.TestCase):
         response = self.client_1.connect()
         assert self.client_1._get_peer_id(self.address_2) is ""
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="requires running rif comms node")
     def test_has_subscriber_self(self):
         # register node 1, subscribe to self, check subscription
         notification = self.client_1.connect()
         self.client_1.subscribe_to(self.address_1)
         assert self.client_1.is_subscribed_to(self.address_1) is True
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="hangs when attempting to sub 1 to 2 without subbing 2 to 2 before")
     def test_has_subscriber(self):
         # register nodes 1 and 2, subscribe from 1 to 2, check subscriptions
         notification_1 = self.client_1.connect()
@@ -97,7 +97,7 @@ class TestRIFCommsClient(unittest.TestCase):
         assert self.client_2.is_subscribed_to(self.address_2) is False
         assert self.client_2.is_subscribed_to(self.address_2) is False
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="hangs when attempting to sub 1 to 2 without subbing 2 to 2 before")
     def test_two_clients_cross_subscription(self):
         # register nodes 1 and 2
         notification_1 = self.client_1.connect()
@@ -114,7 +114,7 @@ class TestRIFCommsClient(unittest.TestCase):
         assert self.client_2.is_subscribed_to(self.address_1) is True
         assert self.client_2.is_subscribed_to(self.address_2) is True
 
-    @pytest.mark.skip(reason="ignore")
+    @pytest.mark.skip(reason="incomplete test")
     def test_disconnect(self):
         # register node 1, get own peer id, disconnect
         notification = self.client_1.connect()
@@ -122,17 +122,16 @@ class TestRIFCommsClient(unittest.TestCase):
         self.client_1.disconnect()
         # TODO check if end comms deletes topics
 
-    @pytest.mark.skip(reason="ignore")
     def test_send_lumino_message(self):
         # this test requires a lumino node started with a comms api matching test_nodes[1]["comms_api"]
-        channel = grpc.insecure_channel(self.api_1)
-        stub = CommunicationsApiStub(channel)
+        stub = CommunicationsApiStub(grpc.insecure_channel(self.api_1))
 
         # TODO: obtain this programmatically
-        channel_id = "16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA"
+        channel_id = "16Uiu2HAmQmHFGepf3eaptGCkPhhw8ggipsrJzZyLTrnd5TJKWDHk"
         # got this from subscription of lumino node
 
-        channel = stub.Subscribe(Channel(channelId=channel_id))
+        sub = stub.Subscribe(Channel(channelId=channel_id))
+        print("sub")
 
         some_raiden_message = {
             'type': 'LockedTransfer',
@@ -184,12 +183,12 @@ class TestRIFCommsClient(unittest.TestCase):
 
         for resp in one_sub_one:
             i += 1
-            print("Respone for 1: ", resp)
+            print("response for 1: ", resp)
             if i == expected_messages:
                 break
 
         for resp in two_sub_one:
             j += 1
-            print("Respone for 2: ", resp)
+            print("response for 2: ", resp)
             if j == expected_messages:
                 break

--- a/raiden/tests/unit/rif_comms/test_rif_comms_client.py
+++ b/raiden/tests/unit/rif_comms/test_rif_comms_client.py
@@ -8,20 +8,20 @@ from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.proto.api_pb2 import Channel, PublishPayload, Msg
 from transport.rif_comms.proto.api_pb2_grpc import CommunicationsApiStub
 
-test_nodes = [
-    {
+test_nodes = dict([
+    (1, {
         "address": to_canonical_address("0x8cb891510dF75C223C53f910A98c3b61B9083c3B"),
         "comms-api": "localhost:5013",
-    },
-    {
+    }),
+    (2, {
         "address": to_canonical_address("0xeBfF0EEe8E2b6952E589B0475e3F0E34dA0655B1"),
         "comms-api": "localhost:5016",
-    },
-    {
+    }),
+    (3, {
         "address": to_canonical_address("0x636BA79E46E0594ECbbEBb4F74B9336Fd4454442"),
         "comms-api": "localhost:5019",
-    },
-]
+    }),
+])
 
 
 @pytest.mark.usefixtures("rif_comms_client")
@@ -79,7 +79,7 @@ class TestRIFCommsClient(unittest.TestCase):
         response = self.client_1.connect()
         assert self.client_1._get_peer_id(self.address_2) is ""
 
-    @pytest.mark.skip(reason="works but subscribed equals False")
+    @pytest.mark.skip(reason="ignore")
     def test_has_subscriber_self(self):
         # register node 1, subscribe to self, check subscription
         notification = self.client_1.connect()

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -44,10 +44,15 @@ class Client:
         Invokes CreateTopicWithRskAddress GRPC API endpoint.
         The resulting notification stream should only be used for receiving messages; use send_message for sending.
         :param rsk_address: destination RSK address for message sending
-        :return: notification stream for receiving messages
+        :return: peer id and notification stream for receiving messages
         """
+        topic_id = None
         # TODO: catch already subscribed and any error
-        return self.stub.CreateTopicWithRskAddress(RskAddress(address=to_checksum_address(rsk_address)))
+        topic = self.stub.CreateTopicWithRskAddress(RskAddress(address=to_checksum_address(rsk_address)))
+        for response in topic:
+            topic_id = response.channelPeerJoined.peerId
+            break
+        return topic_id, topic
 
     def is_subscribed_to(self, rsk_address: Address) -> bool:
         """

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -83,18 +83,18 @@ class Node(TransportNode):
         Iterate over the Notification stream and block thread to receive messages.
         """
         for notification in self._our_topic_stream:
-            raiden_message = self._notification_to_message(notification.channelNewData)
+            raiden_message = self._notification_to_message(notification)
             if raiden_message:
                 self.log.info("incoming message", message=raiden_message)
                 self._handle_message(raiden_message)
 
     @staticmethod
-    def _notification_to_message(notification_data: ChannelNewData) -> RaidenMessage:
+    def _notification_to_message(notification_data: ChannelNewData) -> str:
         """
         :param notification_data: raw data received by the RIF Comms GRPC API
-        :return: a raiden.Message
+        :return: a message payload
         """
-        content_text = notification_data.data
+        content_text = notification_data.channelNewData.data
         """
         ChannelNewData has the following structure:
             from: "16Uiu2HAm8wq7GpkmTDqBxb4eKGfa2Yos79DabTgSXXF4PcHaDhWJ"
@@ -108,9 +108,7 @@ class Node(TransportNode):
             # we first transform the content of the notification data to a dictionary
             content = json.loads(content_text.decode())
             # the message is inside the notification data, encoded by the RIF Comms GRPC api
-            message_string = bytes(content["data"]).decode()
-            message_dict = json.loads(message_string)
-            return message_from_dict(message_dict)
+            return bytes(content["data"]).decode()
         return None
 
     def _handle_message(self, message: RaidenMessage):

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -5,7 +5,6 @@ import structlog
 from eth_utils import is_binary_address
 from gevent import killall, wait
 from greenlet import GreenletExit
-
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress
 from raiden.message_handler import MessageHandler
 from raiden.messages import (
@@ -14,8 +13,7 @@ from raiden.messages import (
     Delivered,
     Processed,
     Ping,
-    Pong,
-    from_dict as message_from_dict
+    Pong
 )
 from raiden.raiden_service import RaidenService
 from raiden.transfer.identifiers import QueueIdentifier

--- a/transport/rif_comms/utils.py
+++ b/transport/rif_comms/utils.py
@@ -1,0 +1,24 @@
+import json
+
+from transport.rif_comms.proto.api_pb2 import ChannelNewData
+
+
+def notification_to_payload(notification_data: ChannelNewData) -> str:
+    """
+    :param notification_data: raw data received by the RIF Comms GRPC API
+    :return: a message payload
+    """
+    content_text = notification_data.channelNewData.data
+    """
+    ChannelNewData has the following structure:
+        from: "16Uiu2HAm8wq7GpkmTDqBxb4eKGfa2Yos79DabTgSXXF4PcHaDhWJ"
+        data: "{\"type\":\"Buffer\",\"data\":[104,101,121]}"
+        nonce: "\216f\225\232d\023e{"
+        channel {
+          channelId: "16Uiu2HAm9otWzXBcFm7WC2Qufp2h1mpRxK1oox289omHTcKgrpRA"
+        }
+    """
+    if content_text:
+        content = json.loads(content_text.decode())  # deserialize `data` dict
+        return bytes(content["data"]).decode()  # deserialize `data.data` field
+    return None


### PR DESCRIPTION
This PR:
1. iterates upon the RIF comms tests (this module is by no means final, though)
    1. adds the `test_nodes` variable for tidiness and removes random addresses.
    2. expands the `rif_comms_client` fixture with RSK and API addresses.
    3. renames some tests for clarity's sake.
    4. updates some test logic based on the latest behavior of the RIF comms node.
    5. removes some tests which were useless (or, in one case, a bit of an overkill for `pytest`) and adds other needed ones (like cross messaging).
    6. clarifies `reason` fields for skipped tests plus some comments.
2. extracts the static method `_notification_to_message` into `rif_comms/utils.py`, and makes it more generic.
    - instead of returning a `RaidenMessage`, now a `str` payload is returned. this `str` is then processed as a raiden message in the RIF comms transport node code.

There are still some `TODOs` to be resolved on the base branch or later down the road. This is meant to be an improvement rather than a final implementation.

builds on #162 