### PR TITLE
bugfix/RLP-828/channel-not-deleted

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -519,9 +519,9 @@ def handle_channel_batch_unlock(raiden: "RaidenService", event: Event):
     )
     assert token_network_state is not None
 
-    if participant1 == raiden.address:
+    if participant1 == raiden.address or participant1 in token_network_state.channelidentifiers_to_channels:
         partner = participant2
-    elif participant2 == raiden.address:
+    elif participant2 == raiden.address or participant2 in token_network_state.channelidentifiers_to_channels:
         partner = participant1
     else:
         log.debug(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1998,8 +1998,7 @@ def handle_channel_settled_light(
     if state_change.channel_identifier == channel_state.identifier:
         set_settled(channel_state, state_change.block_number)
 
-        our_locksroot = state_change.our_onchain_locksroot
-        partner_locksroot = state_change.partner_onchain_locksroot
+        our_locksroot, partner_locksroot = get_locksroot_from_state_change(channel_state.our_state.address, state_change)
 
         should_clear_channel = (
             our_locksroot == EMPTY_MERKLE_ROOT and partner_locksroot == EMPTY_MERKLE_ROOT
@@ -2020,6 +2019,14 @@ def handle_channel_settled_light(
         )
         events.append(onchain_unlock)
     return TransitionResult(channel_state, events)
+
+
+def get_locksroot_from_state_change(our_address: Address, state_change: ContractReceiveChannelSettledLight):
+    if our_address == state_change.participant1:
+        return state_change.our_onchain_locksroot, state_change.partner_onchain_locksroot
+    else:
+        return state_change.partner_onchain_locksroot, state_change.our_onchain_locksroot
+
 
 def handle_channel_newbalance(
     channel_state: NettingChannelState,

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1206,6 +1206,10 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     def token_network_identifier(self) -> TokenNetworkAddress:
         return TokenNetworkAddress(self.canonical_identifier.token_network_address)
 
+    @property
+    def channel_identifier(self) -> ChannelID:
+        return self.canonical_identifier.channel_identifier
+
     def __repr__(self) -> str:
         return (
             "<ContractReceiveChannelBatchUnlock "


### PR DESCRIPTION
### changes
- `raiden/blockchain_events_handler.py`: check if participant is current node, or a handled LC,  instsead of checking only if it's a full node
- Simplify `handle_batch_unlock logic`, as it was duplicating channel deletion
- `handle_batch_unlock` now uses `subdispatch_to_channels_by_participant_address`, using the nodes address if it's payee or payer (it didn't work with payers before) or a lc address if corresponds
- Add `channel_identifier` property to `ContractReceiveChannelBatchUnlock`, as it's needed by `subdispatch_to_channels_by_participant_address`
