### PR TITLE
Bug fix/rlp 912/fixing lock expired lc

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -144,7 +144,6 @@ class MessageHandler:
     @staticmethod
     def handle_message_lockexpired(raiden: RaidenService,
                                    message: LockExpired,
-                                   message_receiver_address: Address,
                                    is_light_client=False) -> None:
         balance_proof = balanceproof_from_envelope(message)
         if is_light_client:


### PR DESCRIPTION
### Problem

Can't make any payments after a lock expired is generated for LC's

### Escenario

LC1 -> LC2 same hub

### Steps to reproduce

* Pull down LC2
* Send a payment from LC1 to LC2
* Wait for the lock expired
* Start LC2
* Try the payment again

### Result 

The payment fails because the nonce is unsynced 

### Solution

The solution was to fix a bad parameter call on message handler for lock expired, basically removing the unsused parameter