### PR TITLE
RLP-932/add-subscription-check-to-payments

### DIFF
--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -62,11 +62,10 @@ class Client:
         :param rsk_address: RSK address which corresponds to the topic which is being checked for subscription
         :return: boolean value indicating whether the client is subscribed or not
         """
-        our_peer_id = self._get_peer_id(self.rsk_address.address)
-        topic_id = self._get_peer_id(to_checksum_address(rsk_address))
+        topic_id = self._get_peer_id(rsk_address)
         return self.stub.HasSubscriber(
             Subscriber(
-                peerId=our_peer_id,
+                peerId=topic_id,
                 channel=Channel(channelId=topic_id)
             )
         ).value

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -240,7 +240,14 @@ class Node(TransportNode):
         """
         Send text message through the RIF Comms client.
         """
-        self._comms_client.subscribe_to(recipient)
+        self.log.info(
+            "RIF Comms sending message", message_payload=payload.replace("\n", "\\n"), recipient=pex(recipient)
+        )
+        if not self._comms_client.is_subscribed_to(recipient):
+            self.log.info(
+                "RIF Comms sending message not subscribed to recipient. Subscribing...", recipient=pex(recipient)
+            )
+            self._comms_client.subscribe_to(recipient)
         # send the message
         self._comms_client.send_message(payload, recipient)  # TODO: exception handling for RIF Comms client
         self.log.info(

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -241,11 +241,11 @@ class Node(TransportNode):
         Send text message through the RIF Comms client.
         """
         self.log.info(
-            "RIF Comms sending message", message_payload=payload.replace("\n", "\\n"), recipient=pex(recipient)
+            "sending message", message_payload=payload.replace("\n", "\\n"), transport="rif_comms", recipient=pex(recipient)
         )
         if not self._comms_client.is_subscribed_to(recipient):
             self.log.info(
-                "RIF Comms sending message not subscribed to recipient. Subscribing...", recipient=pex(recipient)
+                "subscribing to recipient", transport="rif_comms", recipient=pex(recipient)
             )
             self._comms_client.subscribe_to(recipient)
         # send the message


### PR DESCRIPTION
## Description

This pr modifies the rif comms node `send_message` in order to check for subscriptions on message sending.

## Changelog: 

- modified params for hasSubscriber call on rif comms client, now we check for `peerId=topic_id, channel=Channel(channelId=topic_id)` where `topic_id` = recipient peer id

- add is subscribed to call on send message

## Manually tested: 

p2p payment continue working


