### PR TITLE
RLP-793 Fixing send signed close tx error

### DIFF
--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1148,7 +1148,13 @@ def is_transaction_effect_satisfied(
         and isinstance(transaction, ContractSendChannelClose)
         and state_change.token_network_identifier == transaction.token_network_identifier
         and state_change.channel_identifier == transaction.channel_identifier
+    ) or (
+        isinstance(state_change, ContractReceiveChannelClosedLight)
+        and isinstance(transaction, ContractSendChannelClose)
+        and state_change.token_network_identifier == transaction.token_network_identifier
+        and state_change.channel_identifier == transaction.channel_identifier
     )
+
     if is_valid_close:
         return True
 
@@ -1158,6 +1164,7 @@ def is_transaction_effect_satisfied(
         and state_change.token_network_identifier == transaction.token_network_identifier
         and state_change.channel_identifier == transaction.channel_identifier
     )
+
     if is_valid_settle:
         return True
 
@@ -1309,7 +1316,8 @@ def update_queues(iteration: TransitionResult[ChainState], state_change: StateCh
             queue.append(event)
 
         if isinstance(event, ContractSendEvent):
-            chain_state.pending_transactions.append(event)
+            if is_transaction_pending(chain_state, event, state_change):
+                chain_state.pending_transactions.append(event)
 
 
 def state_transition(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1144,12 +1144,8 @@ def is_transaction_effect_satisfied(
     # lost a race against a remote close, and the balance proof data would be
     # the one provided by this node's partner
     is_valid_close = (
-        isinstance(state_change, ContractReceiveChannelClosed)
-        and isinstance(transaction, ContractSendChannelClose)
-        and state_change.token_network_identifier == transaction.token_network_identifier
-        and state_change.channel_identifier == transaction.channel_identifier
-    ) or (
-        isinstance(state_change, ContractReceiveChannelClosedLight)
+        (isinstance(state_change, ContractReceiveChannelClosed) or
+         (isinstance(state_change, ContractReceiveChannelClosedLight)))
         and isinstance(transaction, ContractSendChannelClose)
         and state_change.token_network_identifier == transaction.token_network_identifier
         and state_change.channel_identifier == transaction.channel_identifier


### PR DESCRIPTION
### Problem

When we had a pending close transaction and we pull down the node, the next time we raise lumino again it fails trying to execute the operation again.

### Cause

When we start lumino a process get's the latest snapshot from database to populate the information on the chain_state. There we have a list of pending_transactions. That list contains the pending to send transactions (like close channel, open channel, etc). So if those were not sent out already they will. The problem with this is that for close channel it was failing since it wasn't checking if the operation was still pending after the time the node was down. Basically we had a bad check for pending transactions after being added to the list.

### Solution

Fix the pending transaction check before adding the transaction to the list to be processed.

### TODO

* Run Tests :heavy_check_mark:, [here](https://github.com/rsksmart/lumino/files/5675867/test.results.log) the results compared to [this](https://github.com/anarancio/lumino-docs/blob/master/pytest/results/develop/2020-11-06/summary.txt) base line.
 