### PR TITLE
RLP-949 Mediated payments fix

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -837,7 +837,6 @@ def test_mediate_transfer():
         channels.get_routes_by_index([1]),
         channels.get_sub_channel(0),
         channels.sub_channel_map,
-        channels.nodeaddresses_to_networkstates,
         pseudo_random_generator,
         payer_transfer,
         block_number,
@@ -1266,7 +1265,6 @@ def test_payee_timeout_must_be_equal_to_payer_timeout():
         channel_set.get_routes_by_index([1]),
         channel_set.get_sub_channel(0),
         channel_set.sub_channel_map,
-        channel_set.nodeaddresses_to_networkstates,
         pseudo_random_generator,
         payer_transfer,
         block_number,
@@ -1409,7 +1407,6 @@ def test_mediator_lock_expired_with_new_block():
         possible_routes=channel_set.get_routes_by_index([1]),
         payer_channel=channel_set.get_sub_channel(0),
         channelidentifiers_to_channels=channel_set.sub_channel_map,
-        nodeaddresses_to_networkstates=channel_set.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         payer_transfer=payer_transfer,
         block_number=block_number,
@@ -1465,7 +1462,6 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
         possible_routes=channel_set.get_routes_by_index([1]),
         payer_channel=channel_set.get_sub_channel(0),
         channelidentifiers_to_channels=channel_set.sub_channel_map,
-        nodeaddresses_to_networkstates=channel_set.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         payer_transfer=payer_transfer,
         block_number=block_number,
@@ -1742,52 +1738,6 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
 
     assert secrethash not in channel_set.get_sub_channel(0).our_state.secrethashes_to_unlockedlocks
     assert search_for_item(iteration.events, SendLockExpired, {})
-
-
-def test_filter_reachable_routes():
-    """ Try to mediate a transfer where a node, that is part of the routes_order,
-    was unreachable and became reachable before the locked transfer expired.
-    Expected result is to route the transfer through this node.
-    """
-    partner1 = factories.NettingChannelEndStateProperties(address=HOP1)
-    partner2 = factories.replace(partner1, address=HOP2)
-    channel1 = factories.create(factories.NettingChannelStateProperties(partner_state=partner1))
-    channel2 = factories.create(factories.NettingChannelStateProperties(partner_state=partner2))
-
-    possible_routes = [
-        factories.make_route_from_channel(channel1),
-        factories.make_route_from_channel(channel2),
-    ]
-
-    # Both nodes are online
-    nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP1, HOP2])
-
-    filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
-    )
-
-    assert possible_routes[0] in filtered_routes
-    assert possible_routes[1] in filtered_routes
-
-    # Only HOP2 is online
-    nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP2])
-
-    filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
-    )
-
-    assert possible_routes[0] not in filtered_routes
-    assert possible_routes[1] in filtered_routes
-
-    # None of the route nodes are available
-    nodeaddresses_to_networkstates = factories.make_node_availability_map([])
-
-    filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
-    )
-
-    assert possible_routes[0] not in filtered_routes
-    assert possible_routes[1] not in filtered_routes
 
 
 def test_node_change_network_state_reachable_node():

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -182,24 +182,6 @@ def has_secret_registration_started(
     return is_secret_registered_onchain or has_pending_transaction
 
 
-def filter_reachable_routes(
-    routes: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
-) -> List[RouteState]:
-    """This function makes sure we use reachable routes only."""
-    reachable_routes = []
-
-    for route in routes:
-        node_network_state = nodeaddresses_to_networkstates.get(
-            route.node_address, NODE_NETWORK_UNREACHABLE
-        )
-        # TODO: jonaf2103 NODE_NETWORK_UNKNOWN should be
-        #  removed from this comparison after fixing the reachability issues
-        if node_network_state == NODE_NETWORK_REACHABLE or node_network_state == NODE_NETWORK_UNKNOWN:
-            reachable_routes.append(route)
-
-    return reachable_routes
-
-
 def filter_used_routes(
     transfers_pair: List[MediationPairState], routes: List[RouteState]
 ) -> List[RouteState]:
@@ -1029,7 +1011,6 @@ def mediate_transfer(
     possible_routes: List["RouteState"],
     payer_channel: NettingChannelState,
     channelidentifiers_to_channels: ChannelMap,
-    nodeaddresses_to_networkstates: NodeNetworkStateMap,
     pseudo_random_generator: random.Random,
     payer_transfer: LockedTransferSignedState,
     block_number: BlockNumber,
@@ -1042,8 +1023,8 @@ def mediate_transfer(
     send a refund back to the payer, allowing the payer to try a different
     route.
     """
-    reachable_routes = filter_reachable_routes(possible_routes, nodeaddresses_to_networkstates)
-    available_routes = filter_used_routes(state.transfers_pair, reachable_routes)
+
+    available_routes = filter_used_routes(state.transfers_pair, possible_routes)
 
     assert payer_channel.partner_state.address == payer_transfer.balance_proof.sender
 
@@ -1117,7 +1098,6 @@ def handle_init(
         routes,
         payer_channel,
         channelidentifiers_to_channels,
-        nodeaddresses_to_networkstates,
         pseudo_random_generator,
         from_transfer,
         block_number,
@@ -1217,7 +1197,6 @@ def handle_refundtransfer(
             mediator_state.routes,
             payer_channel,
             channelidentifiers_to_channels,
-            nodeaddresses_to_networkstates,
             pseudo_random_generator,
             payer_transfer,
             block_number,
@@ -1445,7 +1424,6 @@ def handle_node_change_network_state(
         possible_routes=[route],
         payer_channel=payer_channel,
         channelidentifiers_to_channels=channelidentifiers_to_channels,
-        nodeaddresses_to_networkstates={state_change.node_address: state_change.network_state},
         pseudo_random_generator=pseudo_random_generator,
         payer_transfer=mediator_state.waiting_transfer.transfer,
         block_number=block_number,


### PR DESCRIPTION
### Problem
Can't make a mediated payment after reseting the database of the lumino node

### Escenario
Any escenario of mediated payments, but for this bug we test it with
FN1 -> FN2 -> FN3

### Steps to Reproduce

1. Setup the topology
2. Pull down the lumino nodes
3. Clear the lumino databases
4. Start the lumino nodes again
5. Send a mediated payment from FN1 to FN3 through the FN2

### Result
The payment fails because it doesn't have any route available

### Solution
The solution is to remove the filtering function for reachablity on the routes when we are mediating a transfer. That function causes the problem since it uses a map that it doesn't have the updated values due to the reachability issues that we have. So for now we are removing this function and the test for that too.

### Changes

* Removing filter_reachable_routes and the test for that since it was causing the problem of reachability on the mediated payment.

### Scope

This affects the mediated payment flow