### PR TITLE
RLP-951 Concurrent deposit for lc

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -210,60 +210,60 @@ class ConnectionManager:
         token_network_proxy = self.raiden.chain.token_network(self.token_network_identifier)
 
         def join_network_channel():
-            channel_state = views.get_channelstate_for(
-                chain_state=views.state_from_raiden(self.raiden),
-                payment_network_id=self.token_network_identifier,
-                token_address=self.token_address,
-                partner_address=partner_address
-            )
-
-            if not channel_state:
-                return
-
-            joining_funds = min(
-                partner_deposit, self._funds_remaining, self._initial_funding_per_partner
-            )
-            if joining_funds <= 0 or self._leaving_state:
-                return
-
-            if joining_funds <= channel_state.our_state.contract_balance:
-                return
-
-            try:
-                # TODO: creator address cant be None we should specify a value here #jonaf2103
-                self.api.set_total_channel_deposit(
-                    registry_address=self.registry_address,
+            with self.lock:
+                channel_state = views.get_channelstate_for(
+                    chain_state=views.state_from_raiden(self.raiden),
+                    payment_network_id=self.token_network_identifier,
                     token_address=self.token_address,
-                    creator_address=None,
-                    partner_address=partner_address,
-                    total_deposit=joining_funds
+                    partner_address=partner_address
                 )
-            except RaidenRecoverableError:
-                log.info("Channel not in opened state", node=pex(self.raiden.address))
-            except InvalidDBData:
-                raise
-            except RaidenUnrecoverableError as e:
-                should_crash = (
-                    self.raiden.config["environment_type"] != Environment.PRODUCTION
-                    or self.raiden.config["unrecoverable_error_should_crash"]
-                )
-                if should_crash:
-                    raise
 
-                log.critical(str(e), node=pex(self.raiden.address))
-            else:
-                log.info(
-                    "Joined a channel",
-                    node=pex(self.raiden.address),
-                    partner=pex(partner_address),
-                    funds=joining_funds,
+                if not channel_state:
+                    return
+
+                joining_funds = min(
+                    partner_deposit, self._funds_remaining, self._initial_funding_per_partner
                 )
+                if joining_funds <= 0 or self._leaving_state:
+                    return
+
+                if joining_funds <= channel_state.our_state.contract_balance:
+                    return
+
+                try:
+                    # TODO: creator address cant be None we should specify a value here #jonaf2103
+                    self.api.set_total_channel_deposit(
+                        registry_address=self.registry_address,
+                        token_address=self.token_address,
+                        creator_address=None,
+                        partner_address=partner_address,
+                        total_deposit=joining_funds
+                    )
+                except RaidenRecoverableError:
+                    log.info("Channel not in opened state", node=pex(self.raiden.address))
+                except InvalidDBData:
+                    raise
+                except RaidenUnrecoverableError as e:
+                    should_crash = (
+                        self.raiden.config["environment_type"] != Environment.PRODUCTION
+                        or self.raiden.config["unrecoverable_error_should_crash"]
+                    )
+                    if should_crash:
+                        raise
+
+                    log.critical(str(e), node=pex(self.raiden.address))
+                else:
+                    log.info(
+                        "Joined a channel",
+                        node=pex(self.raiden.address),
+                        partner=pex(partner_address),
+                        funds=joining_funds,
+                    )
 
         # Wait for any pending operation in the channel to complete, before
         # deciding on the deposit
         token_network_proxy.lock_and_execute_channel_operation(channel_identifier=channel_identifier,
-                                                               semaphore=self.lock,
-                                                               code_to_block=join_network_channel)
+                                                               blocking_operation=join_network_channel)
 
 
     def retry_connect(self):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -310,11 +310,9 @@ class ProxyTransactionError(RaidenError):
     """ Raised when an operation is sent out to the blockchain and it returns an error and we need to handle it """
 
     def __init__(self,
-                 tx_error_prefix: Optional[str],
-                 tx_error: Optional[Any],
-                 tx_gas_limit: Optional[int]):
-        super().__init__()
+                 tx_error_prefix: str,
+                 tx_error: Optional[Any]):
+        super(RaidenError, self).__init__(f"A proxy transaction error has occurred: {tx_error_prefix}")
         self.tx_error_prefix = tx_error_prefix
         self.tx_error = tx_error
-        self.tx_gas_limit = tx_gas_limit
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -312,7 +312,7 @@ class ProxyTransactionError(RaidenError):
     def __init__(self,
                  tx_error_prefix: str,
                  tx_error: Optional[Any]):
-        super(RaidenError, self).__init__(f"A proxy transaction error has occurred: {tx_error_prefix}")
+        super(ProxyTransactionError, self).__init__(f"A proxy transaction error has occurred: {tx_error_prefix}")
         self.tx_error_prefix = tx_error_prefix
         self.tx_error = tx_error
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -305,3 +305,16 @@ class RawTransactionFailed(RaidenError):
 class UnhandledLightClient(RaidenRecoverableError):
     """Raised if someone tries to create a channel using this node as a hub and the light clients are not registered."""
 
+
+class ProxyTransactionError(RaidenError):
+    """ Raised when an operation is sent out to the blockchain and it returns an error and we need to handle it """
+
+    def __init__(self,
+                 tx_error_prefix: Optional[str],
+                 tx_error: Optional[Any],
+                 tx_gas_limit: Optional[int]):
+        super().__init__()
+        self.tx_error_prefix = tx_error_prefix
+        self.tx_error = tx_error
+        self.tx_gas_limit = tx_gas_limit
+

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -166,7 +166,6 @@ class TokenNetwork:
     def lock_and_execute_channel_operation(self,
                                            channel_identifier: ChannelID,
                                            blocking_operation: Callable) -> Optional[Any]:
-
         with self.channel_blocking_operations[channel_identifier]:
             return blocking_operation()
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -150,7 +150,7 @@ class TokenNetwork:
         # setTotalDeposit calls.
         # has to be in a map also by channel id because at the end it's the same as the other lock
         # we have to lock it by channel, if not the result will be the same, only sequential executions
-        self.deposit_lock: Dict[ChannelID, Semaphore] = defaultdict(Semaphore)
+        self.channel_deposit_blocking_operations: Dict[ChannelID, Semaphore] = defaultdict(Semaphore)
 
     def _call_and_check_result(
         self, block_identifier: BlockSpecification, function_name: str, *args, **kwargs
@@ -733,7 +733,7 @@ class TokenNetwork:
         checking_block = self.client.get_checking_block()
 
         def make_deposit():
-            with self.deposit_lock[channel_identifier]:
+            with self.channel_deposit_blocking_operations[channel_identifier]:
                 previous_total_deposit = self._detail_participant(
                     channel_identifier=channel_identifier,
                     participant=creator,
@@ -869,7 +869,7 @@ class TokenNetwork:
         checking_block = self.client.get_checking_block()
 
         def make_deposit():
-            with self.deposit_lock[channel_identifier]:
+            with self.channel_deposit_blocking_operations[channel_identifier]:
                 previous_total_deposit = self._detail_participant(
                     channel_identifier=channel_identifier,
                     participant=self.node_address,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2225,13 +2225,11 @@ class TokenNetwork:
                 self.client.poll(transaction_hash)
                 tx_error = check_transaction_threw(self.client, transaction_hash)
                 if tx_error:
-                    raise ProxyTransactionError(tx_gas_limit=tx_gas_limit,
-                                                tx_error=tx_error,
-                                                tx_error_prefix="settle call failed")
+                    raise ProxyTransactionError(tx_error_prefix="settle call failed",
+                                                tx_error=tx_error)
             else:
-                raise ProxyTransactionError(tx_gas_limit=tx_gas_limit,
-                                            tx_error=None,
-                                            tx_error_prefix="Call to settle will fail")
+                raise ProxyTransactionError(tx_error_prefix="Call to settle will fail",
+                                            tx_error=None)
 
         try:
             self.lock_and_execute_channel_operation(channel_identifier=channel_identifier,
@@ -2280,7 +2278,7 @@ class TokenNetwork:
             self.client.poll(transaction_hash)
             tx_error = check_transaction_threw(self.client, transaction_hash)
             if tx_error:
-                raise ProxyTransactionError(tx_error=tx_error)
+                raise ProxyTransactionError(tx_error_prefix="settle call failed", tx_error=tx_error)
 
         try:
             self.lock_and_execute_channel_operation(channel_identifier=channel_identifier,
@@ -2288,7 +2286,7 @@ class TokenNetwork:
         except ProxyTransactionError as e:
             self.handle_transaction_error_for_settlement(channel_identifier=channel_identifier,
                                                          checking_block=checking_block,
-                                                         error_prefix="settle call failed",
+                                                         error_prefix=e.tx_error_prefix,
                                                          log_details=log_details,
                                                          partner=partner,
                                                          transaction_error=e.tx_error)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1112,20 +1112,20 @@ class TokenNetwork:
         else:
             onchain_channel_identifier = channel_onchain_detail.channel_identifier
             if onchain_channel_identifier != channel_identifier:
-                raise RaidenUnrecoverableError((
+                raise RaidenUnrecoverableError(
                     f"The provided channel identifier does not match the value "
                     f"on-chain at the provided block ({given_block_identifier}). "
                     f"This call should never have been attempted. "
                     f"provided_channel_identifier={channel_identifier}, "
                     f"onchain_channel_identifier={channel_onchain_detail.channel_identifier}"
-                ))
+                )
 
             if channel_onchain_detail.state != ChannelState.OPENED:
-                raise RaidenUnrecoverableError((
+                raise RaidenUnrecoverableError(
                     f"The channel was not open at the provided block "
                     f"({given_block_identifier}). This call should never have "
                     f"been attempted."
-                ))
+                )
 
         def close_light_channel():
             checking_block = self.client.get_checking_block()
@@ -1163,12 +1163,12 @@ class TokenNetwork:
                     mining_block = int(receipt_or_none["blockNumber"])
 
                     if receipt_or_none["cumulativeGasUsed"] == gas_limit:
-                        raise RaidenUnrecoverableError((
+                        raise RaidenUnrecoverableError(
                             "update transfer failed and all gas was used. Estimate gas "
                             "may have underestimated update transfer, or succeeded even "
                             "though an assert is triggered, or the smart contract code "
                             "has an conditional assert."
-                        ))
+                        )
 
                     partner_details = self._detail_participant(
                         channel_identifier=channel_identifier,
@@ -1207,16 +1207,16 @@ class TokenNetwork:
                 )
 
                 if detail.state < ChannelState.OPENED:
-                    raise RaidenUnrecoverableError((
+                    raise RaidenUnrecoverableError(
                         f"cannot call close channel has not been opened yet. "
                         f"current_state={detail.state}"
-                    ))
+                    )
 
                 if detail.state >= ChannelState.CLOSED:
-                    raise RaidenRecoverableError((
+                    raise RaidenRecoverableError(
                         f"cannot call close on a channel that has been closed already. "
                         f"current_state={detail.state}"
-                    ))
+                    )
 
                 raise RaidenUnrecoverableError("close channel failed for an unknown reason")
 
@@ -1304,20 +1304,20 @@ class TokenNetwork:
         else:
             onchain_channel_identifier = channel_onchain_detail.channel_identifier
             if onchain_channel_identifier != channel_identifier:
-                raise RaidenUnrecoverableError((
+                raise RaidenUnrecoverableError(
                     f"The provided channel identifier does not match the value "
                     f"on-chain at the provided block ({given_block_identifier}). "
                     f"This call should never have been attempted. "
                     f"provided_channel_identifier={channel_identifier}, "
                     f"onchain_channel_identifier={channel_onchain_detail.channel_identifier}"
-                ))
+                )
 
             if channel_onchain_detail.state != ChannelState.OPENED:
-                raise RaidenUnrecoverableError((
+                raise RaidenUnrecoverableError(
                     f"The channel was not open at the provided block "
                     f"({given_block_identifier}). This call should never have "
                     f"been attempted."
-                ))
+                )
 
         def close_channel():
             checking_block = self.client.get_checking_block()
@@ -1364,12 +1364,12 @@ class TokenNetwork:
                     mining_block = int(receipt_or_none["blockNumber"])
 
                     if receipt_or_none["cumulativeGasUsed"] == gas_limit:
-                        raise RaidenUnrecoverableError((
+                        raise RaidenUnrecoverableError(
                             "update transfer failed and all gas was used. Estimate gas "
                             "may have underestimated update transfer, or succeeded even "
                             "though an assert is triggered, or the smart contract code "
                             "has an conditional assert."
-                        ))
+                        )
 
                     partner_details = self._detail_participant(
                         channel_identifier=channel_identifier,
@@ -1408,16 +1408,16 @@ class TokenNetwork:
                 )
 
                 if detail.state < ChannelState.OPENED:
-                    raise RaidenUnrecoverableError((
+                    raise RaidenUnrecoverableError(
                         f"cannot call close channel has not been opened yet. "
                         f"current_state={detail.state}"
-                    ))
+                    )
 
                 if detail.state >= ChannelState.CLOSED:
-                    raise RaidenRecoverableError((
+                    raise RaidenRecoverableError(
                         f"cannot call close on a channel that has been closed already. "
                         f"current_state={detail.state}"
-                    ))
+                    )
 
                 raise RaidenUnrecoverableError("close channel failed for an unknown reason")
 


### PR DESCRIPTION
### Introduction
In light mode we can't make multiple deposit operations from different LC's to one partner concurrently, all those operations are being secuentially executed instead.

### Change
We are changing the way we lock those operations to use the channel identifier instead of the partner address to avoid having to wait for each client. To do this we have to modify token network proxy to put the channel identifier as the key for the lock map.

This affects concurrent deposit, close and settlement operations.

### Pending

1. Manual testing :heavy_check_mark:
2. Run baseline :heavy_check_mark: 

[Here](https://github.com/rsksmart/lumino/files/5704447/test.results.log) the test results, everything is ok compared to [this](https://github.com/anarancio/lumino-docs/blob/master/testing/pytest/results/develop/2020-11-06/summary.txt) baseline.