### PR TITLE
Feature/rlp 927/shutdown lumino if comms stops

### DIFF
--- a/raiden/tests/integration/network/transport/rif_comms/node.py
+++ b/raiden/tests/integration/network/transport/rif_comms/node.py
@@ -63,5 +63,6 @@ class Node:
         try:
             # FIXME: deleting entries in the connections dictionary is causing non-crashing thread exceptions
             self.client.disconnect()
+            self.client.terminate()
         finally:
             CommsProcess.stop(process=self._process)

--- a/raiden/tests/integration/network/transport/rif_comms/node.py
+++ b/raiden/tests/integration/network/transport/rif_comms/node.py
@@ -63,6 +63,5 @@ class Node:
         try:
             # FIXME: deleting entries in the connections dictionary is causing non-crashing thread exceptions
             self.client.disconnect()
-            self.client.terminate()
         finally:
             CommsProcess.stop(process=self._process)

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -97,9 +97,7 @@ class Client:
 
     def terminate(self):
         """
-        Disconnects from RIF Communications Node. Closes grpc connection
         """
-        self.grpc_channel.unsubscribe(lambda: self.grpc_channel.close())
 
     def _get_peer_id(self, rsk_address: Address) -> str:
         """
@@ -117,6 +115,9 @@ class Client:
     def disconnect(self):
         """
          Invokes the EndCommunication GRPC API endpoint.
+         Disconnects from RIF Communications Node. Closes grpc connection
         """
         self.stub.EndCommunication(Void())
+        self.grpc_channel.unsubscribe(lambda: self.grpc_channel.close())
+
 

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -95,10 +95,6 @@ class Client:
         topic_id = self._get_peer_id(to_checksum_address(rsk_address))
         self.stub.CloseTopic(Channel(channelId=topic_id))
 
-    def terminate(self):
-        """
-        """
-
     def _get_peer_id(self, rsk_address: Address) -> str:
         """
         Gets the peer ID associated with a node RSK address.

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -98,9 +98,7 @@ class Client:
     def disconnect(self):
         """
         Disconnects from RIF Communications Node.
-        Invokes the EndCommunication GRPC API endpoint.
         """
-        self.stub.EndCommunication(Void())
         self.grpc_channel.unsubscribe(lambda: self.grpc_channel.close())
 
     def _get_peer_id(self, rsk_address: Address) -> str:
@@ -115,3 +113,9 @@ class Client:
                 details = "Failed to lookup key! No peers from routing table!"
         """
         return self.stub.LocatePeerId(RskAddress(address=to_checksum_address(rsk_address))).address
+
+    def end_communications(self):
+        """
+        Invokes the EndCommunication GRPC API endpoint.
+        """
+        self.stub.EndCommunication(Void())

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -95,9 +95,9 @@ class Client:
         topic_id = self._get_peer_id(to_checksum_address(rsk_address))
         self.stub.CloseTopic(Channel(channelId=topic_id))
 
-    def disconnect(self):
+    def terminate(self):
         """
-        Disconnects from RIF Communications Node.
+        Disconnects from RIF Communications Node. Closes grpc connection
         """
         self.grpc_channel.unsubscribe(lambda: self.grpc_channel.close())
 
@@ -114,8 +114,9 @@ class Client:
         """
         return self.stub.LocatePeerId(RskAddress(address=to_checksum_address(rsk_address))).address
 
-    def end_communications(self):
+    def disconnect(self):
         """
-        Invokes the EndCommunication GRPC API endpoint.
+         Invokes the EndCommunication GRPC API endpoint.
         """
         self.stub.EndCommunication(Void())
+

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -1,11 +1,8 @@
-import sys
 from typing import Any, Dict
 
 import structlog
 from eth_utils import is_binary_address
-from gevent import killall, wait
-from greenlet import GreenletExit
-
+from gevent import wait
 from raiden.exceptions import InvalidAddress, UnknownAddress, UnknownTokenAddress, InvalidProtocolMessage
 from raiden.message_handler import MessageHandler
 from raiden.messages import (
@@ -185,7 +182,6 @@ class Node(TransportNode):
 
         self._comms_client.disconnect()
 
-
     def enqueue_message(self, message: TransportMessage, recipient: Address):
         """
         Queue the message for sending to recipient.
@@ -233,7 +229,8 @@ class Node(TransportNode):
         Send text message through the RIF Comms client.
         """
         self.log.info(
-            "sending message", message_payload=payload.replace("\n", "\\n"), transport="rif_comms", recipient=pex(recipient)
+            "sending message", message_payload=payload.replace("\n", "\\n"), transport="rif_comms",
+            recipient=pex(recipient)
         )
         if not self._comms_client.is_subscribed_to(recipient):
             self.log.info(

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -188,7 +188,7 @@ class Node(TransportNode):
             pass
 
         # end grpc communication
-        self._comms_client.disconnect()
+        self._comms_client.terminate()
         # stop lumino if transport layer stopped
         self.log.warning("RIF Comms transport node stopped, shutting down Lumino")
         sys.exit(1)

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -183,11 +183,7 @@ class Node(TransportNode):
             # During shutdown the log attribute may have already been collected
             pass
 
-        # end grpc communication
-        self._comms_client.terminate()
-        # stop lumino if transport layer stopped
-
-        self.log.warning("RIF Comms transport node stopped, shutting down Lumino")
+        self._comms_client.disconnect()
 
 
     def enqueue_message(self, message: TransportMessage, recipient: Address):

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -153,10 +153,6 @@ class Node(TransportNode):
             # children crashes should throw an exception here
             self._receive_messages()
             self.log.info("RIF Comms Node _run. Listening for messages.")
-        except GreenletExit:  # killed without exception
-            self.stop_event.set()
-            killall([self.greenlet])  # kill comms listener thread
-            raise  # re-raise to keep killed status
         except Exception:
             self.stop()  # ensure cleanup and wait on subtasks
             raise
@@ -190,8 +186,9 @@ class Node(TransportNode):
         # end grpc communication
         self._comms_client.terminate()
         # stop lumino if transport layer stopped
+
         self.log.warning("RIF Comms transport node stopped, shutting down Lumino")
-        sys.exit(1)
+
 
     def enqueue_message(self, message: TransportMessage, recipient: Address):
         """

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -154,7 +154,6 @@ class Node(TransportNode):
             self._receive_messages()
             self.log.info("RIF Comms Node _run. Listening for messages.")
         except GreenletExit:  # killed without exception
-            print("GreenletExit comms")
             self.stop_event.set()
             killall([self.greenlet])  # kill comms listener thread
             raise  # re-raise to keep killed status


### PR DESCRIPTION
## Description 

This PR aims to tackle two issues: 
1. lumino must stop if transport layer is down
2. when rif comms transport node stops, it was calling the endComms stub method, that implies that the topics will be destroyed, and i dont found any use case for that

## Changelog 

- greenlet.kill doesnt make any sense, and also was causing incorrect shutdown behaviour: removed
- rif comms client now has two endpoints, a) disconnect: closes the grpc channel, b) end_communications: [todo pending behaviour]

## Manually tested

- rif comms start
- lumino start
- stop rif comms api server after lumino subscribes to rif comms node
- lumino should output: 
`2020-12-15 22:06:09.188221 [warning  ] RIF Comms transport node stopped, shutting down Lumino [transport.rif_comms.node] greenlet_name=RaidenService._run node:60a12f09`

## Pending

Im not happy with the exception handling and transport.stop invocations between raiden_service and the trasnsport layer. 

there is  exception linking between raiden_service and transport and exception handling into the rif comms transport node class 