### PR TITLE
RLP-960 Fixing matrix server error

### DIFF
--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -21,9 +21,7 @@ DEFAULT_MATRIX_KNOWN_SERVERS = {
         "https://raw.githubusercontent.com/raiden-network/raiden-transport"
         "/master/known_servers.main.yaml"
     ),
-    Environment.DEVELOPMENT: (
-        "https://raw.githubusercontent.com/marcosmartinez7/matrix-known-servers/master/known_servers.test.yaml"
-    ),
+    Environment.DEVELOPMENT: ["http://64.225.11.151"],
 }
 
 DEFAULT_REVEAL_TIMEOUT = 50

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -66,7 +66,8 @@ def _setup_matrix(config):
     if config["transport"]["matrix"].get("available_servers") is None:
         # fetch list of known servers from raiden-network/raiden-tranport repo
         available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[config["environment_type"]]
-        available_servers = get_matrix_servers(available_servers_url)
+        available_servers = available_servers_url if \
+            config["environment_type"] == Environment.DEVELOPMENT else get_matrix_servers(available_servers_url)
         log.debug("Fetching available matrix servers", available_servers=available_servers)
         config["transport"]["matrix"]["available_servers"] = available_servers
 


### PR DESCRIPTION
In this PR we are adding our own matrix homeserver to avoid having availability issues, also removing the yml source for development since we are not going to change this anymore.