### PR TITLE
RLP-928/sender validation

### DIFF
--- a/raiden/tests/integration/network/transport/rif_comms/test_client.py
+++ b/raiden/tests/integration/network/transport/rif_comms/test_client.py
@@ -3,7 +3,7 @@ from grpc._channel import _InactiveRpcError
 
 from raiden.tests.integration.network.transport.rif_comms.node import Node as CommsNode, Config as CommsConfig
 from raiden.tests.integration.network.transport.utils import generate_address
-from transport.rif_comms.utils import notification_to_payload
+from transport.rif_comms.utils import notification_to_payload, get_sender_from_notification
 
 
 @pytest.fixture()
@@ -251,3 +251,28 @@ def test_unsubscribe_from_peers(comms_nodes):
     client_2.unsubscribe_from(address_1)
     assert client_2.is_subscribed_to(address_1) is False
     assert client_1.is_subscribed_to(address_2) is False  # check operations are independent
+
+
+@pytest.mark.parametrize("amount_of_nodes", [2])
+def test_send_message_sender(comms_nodes):
+    comms_node_1, comms_node_2 = comms_nodes[1], comms_nodes[2]
+    client_1, address_1 = comms_node_1.client, comms_node_1.address
+    client_2, address_2 = comms_node_2.client, comms_node_2.address
+
+    # subscribe both nodes to each other
+    _, sub_1_to_2 = client_1.subscribe_to(address_2)
+    _, sub_2_to_1 = client_2.subscribe_to(address_1)
+
+    # send messages and listen
+    client_1.send_message("ping", address_2)
+    client_2.send_message("pong", address_1)
+
+    for resp in sub_1_to_2:
+        sender = get_sender_from_notification(resp)
+        assert sender == address_1
+        break  # only 1 message is expected
+
+    for resp in sub_2_to_1:
+        sender = get_sender_from_notification(resp)
+        assert sender == address_2
+        break  # only 1 message is expected

--- a/transport/matrix/layer.py
+++ b/transport/matrix/layer.py
@@ -95,7 +95,10 @@ class MatrixLayer(TransportLayer[MatrixTransportNode]):
         if config["transport"]["matrix"].get("available_servers") is None:
             # fetch list of known servers from raiden-network/raiden-tranport repo
             available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[self.environment_type]
-            available_servers = get_matrix_servers(available_servers_url)
+            available_servers = available_servers_url \
+                if self.environment_type == Environment.DEVELOPMENT \
+                else get_matrix_servers(available_servers_url)
+
             log.debug("Fetching available matrix servers", available_servers=available_servers)
             config["transport"]["matrix"]["available_servers"] = available_servers
 

--- a/transport/rif_comms/node.py
+++ b/transport/rif_comms/node.py
@@ -23,7 +23,7 @@ from transport.message import Message as TransportMessage
 from transport.node import Node as TransportNode
 from transport.rif_comms.client import Client as RIFCommsClient
 from transport.rif_comms.proto.api_pb2 import Notification
-from transport.rif_comms.utils import notification_to_payload
+from transport.rif_comms.utils import notification_to_payload, get_sender_from_notification
 from transport.utils import MessageQueue
 from transport.utils import validate_and_parse_messages
 
@@ -81,9 +81,10 @@ class Node(TransportNode):
         Iterate over the Notification stream and block thread to receive messages.
         """
         for notification in self._our_topic_stream:
+            sender = get_sender_from_notification(notification)
             payload = notification_to_payload(notification)
             try:
-                for raiden_message in validate_and_parse_messages(payload, None):
+                for raiden_message in validate_and_parse_messages(payload, sender):
                     self.log.info("incoming message", message=raiden_message)
                     self._handle_message(raiden_message)
             except InvalidProtocolMessage:

--- a/transport/rif_comms/utils.py
+++ b/transport/rif_comms/utils.py
@@ -1,5 +1,8 @@
 import json
 
+from eth_utils import to_canonical_address
+
+from raiden.utils import Address
 from transport.rif_comms.proto.api_pb2 import ChannelNewData
 
 
@@ -11,7 +14,12 @@ def notification_to_payload(notification_data: ChannelNewData) -> str:
     content_data = notification_data.channelNewData.data
     """
     ChannelNewData has the following structure:
-        from: "16Uiu2HAm8wq7GpkmTDqBxb4eKGfa2Yos79DabTgSXXF4PcHaDhWJ"
+        peer:  {
+          address: "16Uiu2HAmV4KttHooePhKsDsHQTJUzHH6FLv1hRA86hT5Js994hFz"
+        }
+        sender {
+          address: "0xB2D3c4055C4d6B3832a1ee0eF8a5EB25F4D56292"
+        }
         data: "{\"type\":\"Buffer\",\"data\":[104,101,121]}"
         nonce: "\216f\225\232d\023e{"
         channel {
@@ -22,3 +30,8 @@ def notification_to_payload(notification_data: ChannelNewData) -> str:
         content = json.loads(content_data.decode())  # deserialize `data` dict
         return bytes(content["data"]).decode()  # deserialize `data.data` field
     return ""
+
+
+def get_sender_from_notification(notification_data: ChannelNewData) -> Address:
+    return to_canonical_address(notification_data.sender.address)
+

--- a/transport/rif_comms/utils.py
+++ b/transport/rif_comms/utils.py
@@ -33,5 +33,5 @@ def notification_to_payload(notification_data: ChannelNewData) -> str:
 
 
 def get_sender_from_notification(notification_data: ChannelNewData) -> Address:
-    return to_canonical_address(notification_data.sender.address)
+    return to_canonical_address(notification_data.channelNewData.sender.address)
 

--- a/transport/rif_comms/utils.py
+++ b/transport/rif_comms/utils.py
@@ -1,8 +1,8 @@
 import json
 
+from eth_typing import Address
 from eth_utils import to_canonical_address
 
-from raiden.utils import Address
 from transport.rif_comms.proto.api_pb2 import ChannelNewData
 
 
@@ -33,5 +33,14 @@ def notification_to_payload(notification_data: ChannelNewData) -> str:
 
 
 def get_sender_from_notification(notification_data: ChannelNewData) -> Address:
-    return to_canonical_address(notification_data.channelNewData.sender.address)
+    """
+    Returns the sender from a notification received through a RIF Comms node. The sender represents the Lumino node
+    that sends the message.
+    @param notification_data notification data received from the subscription stream
+    @returns the sender address
+    """
+    try:
+        return to_canonical_address(notification_data.channelNewData.sender.address)
+    except AttributeError:
+        return Address(b"")
 

--- a/transport/utils.py
+++ b/transport/utils.py
@@ -270,6 +270,13 @@ def validate_and_parse_messages(data, peer_address) -> List[Message]:
                     peer_address=pex(peer_address),
                 )
                 continue
-            # TODO message must be signed by sender
+            if message.sender != peer_address:
+                log.warning(
+                    "ToDevice Message not signed by sender!",
+                    message=message,
+                    signer=message.sender,
+                    peer_address=pex(peer_address),
+                )
+                continue
             messages.append(message)
     return messages


### PR DESCRIPTION
## Description

On the latest release of rif comms pubsub bootnode, the team introduced a `sender` field that identifies the sender of a message

On this PR, we validate that the `recovered address` from a signature of a received raiden message is equals to the `sender`

This way, we validate that the messages are sent by the sender unequivocally (*)

(*) A handshake between lumino and rif comms is needed in order to take that sender attribute as a secure data field.

## Changelog 

- created `get_sender_from_notification` method that returns the sender from a notification
-  added the peer_address param on the reception of rif comms messages 
- re-added the sender validation on `validate_and_parse_messages`

## Acceptance criteria

- [x] unit tests should pass
- [x] payments using matrix should work 
- [x] payments using rif comms shuld work