### PR TITLE
RLP-959/use private rooms

### DIFF
--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -49,9 +49,7 @@ def environment_type_to_contracts_version(environment_type: Environment) -> str:
 def setup_environment(config: Dict[str, Any], environment_type: Environment) -> None:
     """Sets the config depending on the environment type"""
     # interpret the provided string argument
-    if environment_type == Environment.PRODUCTION:
-        # Safe configuration: restrictions for mainnet apply and matrix rooms have to be private
-        config["transport"]["matrix"]["private_rooms"] = True
+    config["transport"]["matrix"]["private_rooms"] = True
 
     config["environment_type"] = environment_type
 


### PR DESCRIPTION
## Description 

On this PR the `config["transport"]["matrix"]["private_rooms"] ` is set to True on any scenario.

Previously, it was only for Production, but since we always use development environment, we must change this to protect the messages on mainnet.

We use development env even in mainnet, because Production env is too coupled with raiden contracts, matrix servers, etc.

Thats something we need to improve.

## Acceptance criteria

- [x] unit test should pass
- [x] matrix payments using private rooms works