### PR TITLE
RLP-970 Fixing register secret loop error

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1073,7 +1073,7 @@ class TokenNetwork:
         Raises:
             RaidenRecoverableError: If the close call failed but it is not
                 critical.
-            RaidenUnrecoverableError: If the operation was ilegal at the
+            RaidenUnrecoverableError: If the operation was illegal at the
                 `given_block_identifier` or if the channel changes in a way that
                 cannot be recovered.
         """

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -612,7 +612,9 @@ def handle_block(
         lock_expiration_threshold=channel.get_receiver_expiration_threshold(lock),
     )
 
-    if lock_has_expired and target_state.state != "expired":
+    target_state_expired = target_state.state == TargetTransferState.EXPIRED
+
+    if lock_has_expired and not target_state_expired:
         failed = EventUnlockClaimFailed(
             identifier=transfer.payment_identifier,
             secrethash=transfer.lock.secrethash,
@@ -620,7 +622,7 @@ def handle_block(
         )
         target_state.state = TargetTransferState.EXPIRED
         events = [failed]
-    elif secret_known:
+    elif secret_known and not target_state_expired:
         events = events_for_onchain_secretreveal(
             target_state=target_state,
             channel_state=channel_state,


### PR DESCRIPTION
#### Introduction
When we have a low balance on our account and that's insufficient to send a register secret transaction to the chain it fails, when it fails it keeps repeating until the operation can be executed, this loop is caused by a missing condition when we create the event for register secret light. This creates a loop that generates messages for the light client and increases the database size indefinitely.

#### Fix
Adding the condition solves the problem, now we have a correct condition when we create the event for this.