### PR TITLE
RLP-982: remove subscription timeout

### DIFF
--- a/raiden/tests/integration/network/transport/rif_comms/test_client.py
+++ b/raiden/tests/integration/network/transport/rif_comms/test_client.py
@@ -557,16 +557,6 @@ def test_client_timeouts():
             rsk_address=utility_addr
         )
 
-        # subscribe_to timeout
-        expect_error(
-            expected_exception=TimeoutException,
-            expected_mapped_type=None,
-            expected_code=StatusCode.DEADLINE_EXCEEDED,
-            expected_message=expected_timeout_message,
-            call=client.subscribe_to,
-            rsk_address=client.rsk_address.address
-        )
-
         # _is_subscribed_to timeout
         expect_error(
             expected_exception=TimeoutException,

--- a/transport/rif_comms/client.py
+++ b/transport/rif_comms/client.py
@@ -83,8 +83,7 @@ class Client:
             RskSubscription(
                 topic=RskAddress(address=to_checksum_address(rsk_address)),
                 subscriber=self.rsk_address
-            ),
-            timeout=self.grpc_client_timeout
+            )
         )
         for response in topic:
             topic_id = response.channelPeerJoined.peerId


### PR DESCRIPTION
This PR tackles issue [RLP-982](https://jirainfuy.atlassian.net/browse/RLP-982), which is about removing the RIF Comms client timeout parameter from the subscription creation calls.

[More information is detailed in the issue](https://jirainfuy.atlassian.net/browse/RLP-982).