### PR TITLE
Fixing eth_getLogs timeout

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -37,6 +37,7 @@ RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT = int(0.075 * 10 ** 18)
 RED_EYES_PER_TOKEN_NETWORK_LIMIT = int(250 * 10 ** 18)
 
 GENESIS_BLOCK_NUMBER = BlockNumber(0)
+MILLION_BLOCK_NUMBER = BlockNumber(1000000)
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value
 STATE_PRUNING_AFTER_BLOCKS = 64

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -7,7 +7,8 @@ from web3.utils.filters import Filter
 
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.network.proxies.token_network import ChannelDetails, TokenNetwork
-from raiden.utils.filters import decode_event, get_filter_args_for_specific_event_from_channel
+from raiden.utils.filters import decode_event, get_filter_args_for_specific_event_from_channel, \
+    get_block_number_from_million_or_genesis
 from raiden.utils.typing import (
     AdditionalHash,
     Address,
@@ -34,7 +35,7 @@ class PaymentChannel:
             raise ValueError(f"channel_identifier {channel_identifier} is not a uint256")
 
         # FIXME: Issue #3958
-        from_block = GENESIS_BLOCK_NUMBER
+        from_block = get_block_number_from_million_or_genesis(token_network.proxy.contract.web3)
 
         # For this check it is perfectly fine to use a `latest` block number.
         # If the channel happened to be closed, even if the chanel is already

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -28,6 +28,7 @@ from web3.utils.empty import empty
 from web3.utils.toolz import assoc
 
 from raiden import constants
+from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.exceptions import (
     AddressWithoutCode,
     EthNodeCommunicationError,
@@ -42,7 +43,7 @@ from raiden.network.rpc.middleware import (
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils import pex, privatekey_to_address
 from raiden.utils.ethereum_clients import is_supported_client
-from raiden.utils.filters import StatelessFilter
+from raiden.utils.filters import StatelessFilter, get_block_number_from_million_or_genesis
 from raiden.utils.solc import (
     solidity_library_symbol,
     solidity_resolve_symbols,
@@ -855,11 +856,12 @@ class JSONRPCClient:
         self,
         contract_address: Address,
         topics: List[str] = None,
-        from_block: BlockSpecification = 0,
+        from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
         to_block: BlockSpecification = "latest",
     ) -> List[Dict]:
         """ Get events for the given query. """
         logs_blocks_sanity_check(from_block, to_block)
+        from_block = get_block_number_from_million_or_genesis(self.web3)
         return self.web3.eth.getLogs(
             {
                 "fromBlock": from_block,

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -6,7 +6,7 @@ from web3.utils.abi import filter_by_type
 from web3.utils.events import get_event_data
 from web3.utils.filters import LogFilter, construct_event_filter_params
 
-from raiden.constants import GENESIS_BLOCK_NUMBER
+from raiden.constants import GENESIS_BLOCK_NUMBER, MILLION_BLOCK_NUMBER
 from raiden.utils import block_specification_to_number
 from raiden.utils.typing import (
     Any,
@@ -130,7 +130,8 @@ class StatelessFilter(LogFilter):
         with self._lock:
             result: List[Dict[str, Any]] = []
             filter_from_number = block_specification_to_number(
-                block=self.filter_params.get("fromBlock", GENESIS_BLOCK_NUMBER), web3=self.web3
+                block=self.filter_params.get("fromBlock", get_block_number_from_million_or_genesis(self.web3)),
+                web3=self.web3
             )
             from_block_number = max(filter_from_number, self._last_block + 1)
 
@@ -148,6 +149,7 @@ class StatelessFilter(LogFilter):
     def get_all_entries(self, block_number: BlockNumber = None):
         with self._lock:
             filter_params = self.filter_params.copy()
+            filter_params["fromBlock"] = get_block_number_from_million_or_genesis(self.web3)
             block_number = block_number or self.web3.eth.blockNumber
 
             if self.filter_params.get("toBlock") in ("latest", "pending"):
@@ -155,9 +157,17 @@ class StatelessFilter(LogFilter):
 
             result = self.web3.eth.getLogs(filter_params)
             to_block = filter_params.get("toBlock")
+
             if to_block:
                 self._last_block = block_specification_to_number(block=to_block, web3=self.web3)
             else:
                 self._last_block = block_number
-
             return result
+
+
+def get_block_number_from_million_or_genesis(web3):
+    current_block = web3.eth.blockNumber
+    if current_block < MILLION_BLOCK_NUMBER:
+        return GENESIS_BLOCK_NUMBER
+    else:
+        return MILLION_BLOCK_NUMBER


### PR DESCRIPTION
### Introduction

When we run lumino in a chain with to many blocks from genesis block we have an issue because lumino try to fetch all the events from genesis to latest block. That causes a timeout and the lumino node fails to start. This PR aims to fix that fetching events from 1 million block to latest instead. This applies only to chains with more than 1 million blocks.