### PR TITLE
RLP-990/invalid-balance-proof-multi-token

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -332,7 +332,7 @@ def handle_channel_closed(raiden: "RaidenService", event: Event):
                 if channel_state.our_state.address == closing_participant \
                 else channel_state.our_state.address
             latest_non_closing_balance_proof = LightClientMessageHandler.get_latest_light_client_non_closing_balance_proof(
-                channel_state.identifier, non_closing_participant, raiden.wal.storage
+                channel_state.identifier, non_closing_participant, token_network_identifier, raiden.wal.storage
             )
             channel_closed = ContractReceiveChannelClosedLight(
                 transaction_hash=transaction_hash,

--- a/raiden/lightclient/handlers/light_client_message_handler.py
+++ b/raiden/lightclient/handlers/light_client_message_handler.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import structlog
 from eth_utils import to_checksum_address
-
 from raiden.lightclient.lightclientmessages.light_client_non_closing_balance_proof import \
     LightClientNonClosingBalanceProof
 from raiden.lightclient.models.light_client_payment import LightClientPayment, LightClientPaymentStatus
@@ -386,8 +385,16 @@ class LightClientMessageHandler:
         return storage.write_light_client_non_closing_balance_proof(non_closing_balance_proof_data)
 
     @classmethod
-    def get_latest_light_client_non_closing_balance_proof(cls, channel_id: int, non_closing_participant: Address, storage: SerializedSQLiteStorage):
-        latest_update_balance_proof_data = storage.get_latest_light_client_non_closing_balance_proof(channel_id, non_closing_participant)
+    def get_latest_light_client_non_closing_balance_proof(cls,
+                                                          channel_id: int,
+                                                          non_closing_participant: Address,
+                                                          token_network_address: Address,
+                                                          storage: SerializedSQLiteStorage):
+        latest_update_balance_proof_data = storage.get_latest_light_client_non_closing_balance_proof(
+            channel_id,
+            non_closing_participant,
+            token_network_address
+        )
         if latest_update_balance_proof_data:
             balance_proof_dict = json.loads(latest_update_balance_proof_data[7])
             balance_proof = Unlock.from_dict(balance_proof_dict) \

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1767,7 +1767,8 @@ class TokenNetwork:
         finally:
             # we need to delete the non closing balance proof from the database to avoid re-send it
             log.info("Deleting non closing balance proof for channel id " + str(channel_identifier), **log_details)
-            raiden.wal.storage.delete_light_client_non_closing_balance_proof(channel_id=channel_identifier)
+            raiden.wal.storage.delete_light_client_non_closing_balance_proof(channel_id=channel_identifier,
+                                                                             token_network_addresss=self.address)
 
     def update_transfer(
         self,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -567,11 +567,13 @@ class RaidenEventHandler(EventHandler):
         raiden: "RaidenService", channel_update_event: ContractSendChannelUpdateTransferLight
     ):
         balance_proof = channel_update_event.balance_proof
+        token_network_identifier = channel_update_event.token_network_identifier
 
         # checking that this balance proof exists on the database
         db_balance_proof = raiden.wal.storage.get_latest_light_client_non_closing_balance_proof(
             channel_id=balance_proof.channel_identifier,
-            non_closing_participant=channel_update_event.lc_address
+            non_closing_participant=channel_update_event.lc_address,
+            token_network_address=token_network_identifier
         )
 
         if db_balance_proof:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -1458,7 +1458,8 @@ class SQLiteStorage:
         )
         return cursor.fetchone()
 
-    def get_latest_light_client_non_closing_balance_proof(self, channel_id, non_closing_participant):
+    def get_latest_light_client_non_closing_balance_proof(self, channel_id, non_closing_participant,
+                                                          token_network_address):
         cursor = self.conn.cursor()
         cursor.execute(
             """
@@ -1472,16 +1473,18 @@ class SQLiteStorage:
                    balance_proof,
                    lc_balance_proof_signature
             FROM light_client_balance_proof
-            WHERE channel_id  = ? AND sender = ?
+            WHERE channel_id  = ? AND sender = ? and token_network_address = ?
             ORDER BY nonce DESC
             """,
-            (channel_id, to_checksum_address(non_closing_participant)),
+            (channel_id, to_checksum_address(non_closing_participant), to_checksum_address(token_network_address)),
         )
         return cursor.fetchone()
 
-    def delete_light_client_non_closing_balance_proof(self, channel_id):
+    def delete_light_client_non_closing_balance_proof(self, channel_id, token_network_addresss):
         with self.write_lock, self.conn:
-            self.conn.execute("DELETE FROM light_client_balance_proof WHERE channel_id = ?", (channel_id,))
+            self.conn.execute(
+                "DELETE FROM light_client_balance_proof WHERE channel_id = ? and token_network_address = ?",
+                (channel_id, to_checksum_address(token_network_addresss),))
 
     def get_light_client_payment_locked_transfer(self,
                                                  payment_identifier,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -1473,18 +1473,18 @@ class SQLiteStorage:
                    balance_proof,
                    lc_balance_proof_signature
             FROM light_client_balance_proof
-            WHERE channel_id  = ? AND sender = ? and token_network_address = ?
+            WHERE channel_id  = ? AND sender = ? AND token_network_address = ?
             ORDER BY nonce DESC
             """,
             (channel_id, to_checksum_address(non_closing_participant), to_checksum_address(token_network_address)),
         )
         return cursor.fetchone()
 
-    def delete_light_client_non_closing_balance_proof(self, channel_id, token_network_addresss):
+    def delete_light_client_non_closing_balance_proof(self, channel_id, token_network_address):
         with self.write_lock, self.conn:
             self.conn.execute(
-                "DELETE FROM light_client_balance_proof WHERE channel_id = ? and token_network_address = ?",
-                (channel_id, to_checksum_address(token_network_addresss),))
+                "DELETE FROM light_client_balance_proof WHERE channel_id = ? AND token_network_address = ?",
+                (channel_id, to_checksum_address(token_network_address),))
 
     def get_light_client_payment_locked_transfer(self,
                                                  payment_identifier,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1934,6 +1934,7 @@ def handle_channel_closed_light(
                 triggered_by_block_hash=state_change.block_hash,
                 lc_bp_signature=state_change.latest_update_non_closing_balance_proof_data.lc_balance_proof_signature
             )
+
             channel_state.update_transaction = TransactionExecutionStatus(
                 started_block_number=state_change.block_number,
                 finished_block_number=None,

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -520,7 +520,6 @@ class ContractReceiveChannelClosedLight(ContractReceiveStateChange):
             canonical_identifier=CanonicalIdentifier.from_dict(data["canonical_identifier"]),
             block_number=BlockNumber(int(data["block_number"])),
             block_hash=BlockHash(deserialize_bytes(data["block_hash"])),
-            closing_participant=to_canonical_address(data["closing_participant"]),
             non_closing_participant=to_canonical_address(data["non_closing_participant"]),
             latest_update_non_closing_balance_proof_data=latest_update_non_closing_balance_proof_data
         )


### PR DESCRIPTION
## Description
This PR aims to fix the issue related to closing light channels when a LC participant has channels on more than a single token.

for example: 
LC - FN = channel on Lumino Token
LC - FN = channel on RIF Token

## The problems 
1. The query that was getting the latest balance proof for a light client wasn't taking into account the `token_network_address` field.
2. Also, the `from_dict` method of `ContractReceiveChannelClosedLight`, was wrong, and it was causing that the node could not recover from a shutdown and startup with state changes reconstruction. 

## The fixes 
1. Add `token_network_address` to the query and the methods that use it.
2. Removed `closing_participant` from `ContractReceiveChannelClosedLight.from_dict` since it isn't an attribute of that class.