### PR TITLE
RLP-984 Fixing light payments without rbtc

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -2269,7 +2269,7 @@ class RestAPI:
         self.raiden_api.unlock_payment_light(signed_tx, token_address)
         return api_response(result=dict(), status_code=HTTPStatus.OK)
 
-    @api_safe_operation(is_light_client=True, lc_balance_required=True)
+    @api_safe_operation(is_light_client=True, lc_balance_required=False)
     def create_light_client_payment(
         self,
         registry_address: typing.PaymentNetworkID,


### PR DESCRIPTION
This PR fixes an error that we introduce when we created the api safe operation decorator for light operations. For payments there is not need to have rbtc balance since those operations are off chain operations. The fix basically is to change a flag to skip the rbtc balance check.