### PR TITLE
RLP-1015: re-enable rif comms unsubscribe test

### DIFF
--- a/raiden/tests/integration/network/transport/rif_comms/test_client.py
+++ b/raiden/tests/integration/network/transport/rif_comms/test_client.py
@@ -456,7 +456,6 @@ def test_unsubscribe_from_non_subscribed_address(comms_clients):
 
 
 @pytest.mark.parametrize("nodes_to_clients", [{"A": 1}])
-@pytest.mark.xfail(reason="wrong error code/msg from comms")
 def test_unsubscribe_from_invalid_address(comms_clients):
     client = comms_clients[1]
 


### PR DESCRIPTION
This PR fixes issue [RLP-1015](https://jirainfuy.atlassian.net/browse/RLP-1015) from the Lumino side, which is about the RIF Comms "unsubscribe from invalid address" integration test failing. The failure is due to an incorrect error code thrown from the RIF Comms side.

After [RIF Comms PR #36](https://github.com/rsksmart/rif-communications-pubsub-bootnode/pull/36) was merged, only the `xfail` mark was needed to be removed from this side.

I've ran this test repeatedly before and after updating the `grpc-api` code and verified that the results are correct and as expected.

I've also successfully ran the entire `rif-comms` integration tests suite with no errors after this change:
```shell
(testEnv) rafa@rafa-laptop:~/repos/github/rsksmart/lumino/raiden/tests/integration/network/transport/rif_comms$ pytest test_client.py 
======================================================================================================== test session starts ========================================================================================================
platform linux -- Python 3.7.9, pytest-5.2.0, py-1.10.0, pluggy-0.13.1
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/rafa/repos/github/rsksmart/lumino/raiden/tests/integration/network/transport/rif_comms/.hypothesis/examples')
rootdir: /home/rafa/repos/github/rsksmart/lumino, inifile: setup.cfg
plugins: timeout-1.3.3, select-0.1.2, hypothesis-3.88.3, random-0.2, cov-2.5.1, repeat-0.9.1
timeout: 540.0s
timeout method: signal
timeout func_only: False
collected 31 items                                                                                                                                                                                                                  

test_client.py ...............................                                                                                                                                                                                [100%]

================================================================================================== 31 passed in 565.01s (0:09:25) ===================================================================================================
```