### PR TITLE
RLP-1028: invoice payment w/decimal amount

### DIFF
--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -546,7 +546,7 @@ class InvoiceCreateSchema(BaseSchema):
     currency_symbol = fields.String(required=True, missing=None)
     token_address = AddressField(required=True)
     partner_address = AddressField(required=True)
-    amount = fields.Integer(default=None, missing=None)
+    amount = fields.Float(default=None, missing=None)
     expires = fields.Integer(default=None, missing=None)
 
     class Meta:

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -105,7 +105,7 @@ PaymentHashInvoice = NewType("PaymentHashInvoice", T_PaymentHashInvoice)
 T_PaymentAmount = int
 PaymentAmount = NewType("PaymentAmount", T_PaymentAmount)
 
-T_InvoiceAmount = int
+T_InvoiceAmount = float
 InvoiceAmount = NewType("InvoiceAmount", T_InvoiceAmount)
 
 T_Invoice_Expires = int


### PR DESCRIPTION
This PR solves issue [RLP-1028](https://jirainfuy.atlassian.net/browse/RLP-1028), which is about generating invoices with decimal amounts through the Lumino REST API.

I've manually verified generating and paying invoices between 2 local nodes, using both integer and decimal amounts.