### PR TITLE
RLP-1031 Removing SQL print for payments on full node

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -992,9 +992,6 @@ class SQLiteStorage:
 
         cursor = self.conn.cursor()
 
-        print(query[0])
-        print(query[1])
-
         cursor.execute(
             query[0],
             query[1],


### PR DESCRIPTION
In this PR we are removing the sql prints on the payments access page to the log of the node.