### PR TITLE
RLP-1035 Adding missing dependencies on requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,6 @@ bump2version==0.5.8
 matrix-synapse==1.5.1
 json5
 pytest-repeat
+Pygments==2.7.4
+PyHamcrest==2.0.2
+Twisted==20.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,6 @@ git+git://github.com/infuy/web3.py@rsk-4.8.2#egg=web3
 # RIF Comms protobuffer
 grpcio-tools==1.33.2
 grpcio==1.33.2
+Pygments==2.7.4
+PyHamcrest==2.0.2
+Twisted==20.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,3 @@ git+git://github.com/infuy/web3.py@rsk-4.8.2#egg=web3
 # RIF Comms protobuffer
 grpcio-tools==1.33.2
 grpcio==1.33.2
-Pygments==2.7.4
-PyHamcrest==2.0.2
-Twisted==20.3.0


### PR DESCRIPTION
### introduction

In this PR we are fixing an error on the testing dependencies, this is related to:

[RLP-1035](https://jirainfuy.atlassian.net/browse/RLP-1035)
[RLP-714](https://jirainfuy.atlassian.net/browse/RLP-714)

### Changes

Adding these dependencies to the `requirement-dev.txt` file:

```
Pygments==2.7.4
PyHamcrest==2.0.2
Twisted==20.3.0
```