### PR TITLE
RLP-1043: channel details refresh fix

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -478,7 +478,7 @@ class APIServer(Runnable):
             self._set_ui_endpoint()
             for route in (
                 '/ui/<path:file_name>', '/ui', '/ui/', '/index.html', '/', '/dashboard', '/tokens', '/payments',
-                '/channels'):
+                '/channels', '/channelDetail'):
                 self.flask_app.add_url_rule(
                     route, route, view_func=self._serve_webui, methods=("GET",)
                 )


### PR DESCRIPTION
This PR implements a solution for [RLP-1043](https://jirainfuy.atlassian.net/browse/RLP-1043), which is about the _Channel Details_ page not refreshing correctly.