### PR TITLE
RLP-1061 Fixing leave network to be a safe operation

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -865,6 +865,7 @@ class RestAPI:
 
         return api_response(result=dict(), status_code=HTTPStatus.NO_CONTENT)
 
+    @api_safe_operation()
     def leave(self, registry_address: typing.PaymentNetworkID, token_address: typing.TokenAddress):
         log.debug(
             "Leaving token network",


### PR DESCRIPTION
This PR fixes the leave network functionallity to be safe, now the node will always handle the errors as a response instead of stop working.