### PR TITLE
PP-69: timezone startup crash

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 aniso8601==3.0.2
 treq==20.4.1
-
+tzlocal<3.0
 appnope==0.1.0
 asn1crypto==0.24.0
 attrdict==2.0.0


### PR DESCRIPTION
Lumino is crashing with the following error at startup:

``` 
TypeError: Only timezones from the pytz library are supported
```

This PR implements a fix based on adding a new constraint.

[Source](https://github.com/Yelp/elastalert/issues/2968)